### PR TITLE
fix(skia): added workaround for Ripple opacity issue

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/NavigationView.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/NavigationView.xaml
@@ -1,10 +1,11 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:material="using:Uno.Material.Controls"
 					xmlns:media="using:Microsoft.UI.Xaml.Media"
 					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
+					xmlns:skia="http://uno.ui/skia"
 					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -12,7 +13,7 @@
 					xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
 					xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives"
-					mc:Ignorable="xamarin contract4NotPresent contract7NotPresent">
+					mc:Ignorable="skia xamarin contract4NotPresent contract7NotPresent">
 
 	<!--
 		Source taken/modified from: https://github.com/unoplatform/uno/tree/2e4c84310d8f88f24d2cae284cec8f5c93375a22
@@ -1647,7 +1648,9 @@
 								BorderThickness="{TemplateBinding BorderThickness}" />
 						<Border Margin="{TemplateBinding Padding}">
 							<!-- dont apply Margin on Ripple, as it will be applied twice (on the Ripple and on its template root) -->
+							<!-- material#446: skia:Opacity to workaround Ripple opacity issue -->
 							<material:Ripple Feedback="{StaticResource NavigationViewRippleFeedback}"
+											 skia:Opacity="0.12"
 											 CornerRadius="{TemplateBinding CornerRadius}" />
 						</Border>
 


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.material#446

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?
added workaround for Ripple opacity issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [x] Tested on Skia.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)