### PR TITLE
fix: Workaround invalid absolute center for animation

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AnimationSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AnimationSamplePage.xaml
@@ -133,11 +133,10 @@
 											   Width="40"
 											   Height="40"
 											   Opacity="1"
-											   Grid.Column="1">
+											   Grid.Column="1"
+											   RenderTransformOrigin=".5,.5">
 										<Rectangle.RenderTransform>
-											<RotateTransform x:Name="RotateTransform1"
-															 CenterX="20"
-															 CenterY="20" />
+											<RotateTransform x:Name="RotateTransform1" />
 										</Rectangle.RenderTransform>
 									</Rectangle>
 								</Grid>
@@ -184,11 +183,10 @@
 									<Rectangle Fill="{StaticResource UnoBlueColor}"
 											   Width="40"
 											   Height="40"
-											   Grid.Column="1">
+											   Grid.Column="1"
+											   RenderTransformOrigin=".5,.5">
 										<Rectangle.RenderTransform>
-											<ScaleTransform x:Name="ScaleTransform1"
-															CenterX="20"
-															CenterY="20" />
+											<ScaleTransform x:Name="ScaleTransform1" />
 										</Rectangle.RenderTransform>
 									</Rectangle>
 								</Grid>


### PR DESCRIPTION
workaround https://github.com/unoplatform/uno/issues/5111

## Workaround
Animation sample are not working

## What is the current behavior?
When using absolute center for animations, element is miss-aligned on iOS

## What is the new behavior?
Use relative center instead

## PR Checklist
- [x] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
