### PR TITLE
fix: Disable NavigationView compact mode, make pane wider

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
@@ -28,14 +28,19 @@
 		<muxc:NavigationView Grid.Row="2"
 							 x:Name="NavigationViewControl"
 							 OpenPaneLength="220"
-							 CompactModeThresholdWidth="99999"
-							 ExpandedModeThresholdWidth="{StaticResource DesktopAdaptiveThresholdWidth}"
 							 IsSettingsVisible="False"
+                             IsPaneOpen="True"
+                             IsPaneVisible="True"
+                             IsPaneToggleButtonVisible="False"
 							 IsBackButtonVisible="Collapsed"
+                             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
+                             SizeChanged="NavigationViewControl_SizeChanged"
+                             PaneDisplayMode="LeftMinimal"
 							 IsBackEnabled="False"
 							 IsTabStop="False">
 			<muxc:NavigationView.PaneHeader>
-				<Grid>
+                <!-- Left padding for overlay toggle button -->
+                <Grid Padding="24,0,0,0">
 					<!-- Image -->
 					<Image Source="{ThemeResource UnoLogoImageSource}"
 						   Height="101"
@@ -59,5 +64,12 @@
 			   Grid.RowSpan="3"
 			   Visibility="Collapsed"
 			   xamarin:Style="{StaticResource NativeDefaultFrame}" />
-	</Grid>
+
+        <!-- Custom pane toggle button -->
+        <Button 
+            Grid.Row="2" 
+            Click="NavViewToggleButton_Click" 
+            HorizontalAlignment="Left" 
+            Style="{StaticResource PaneToggleButtonStyle}" />
+    </Grid>
 </UserControl>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
@@ -27,7 +27,7 @@
 		<!-- We set CompactModeThresholdWidth to a very high value so that it never happens. We don't want to use the compact mode. -->
 		<muxc:NavigationView Grid.Row="2"
 							 x:Name="NavigationViewControl"
-							 OpenPaneLength="220"
+							 OpenPaneLength="260"
 							 IsSettingsVisible="False"
                              IsPaneOpen="True"
                              IsPaneVisible="True"

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml
@@ -33,7 +33,6 @@
                              IsPaneVisible="True"
                              IsPaneToggleButtonVisible="False"
 							 IsBackButtonVisible="Collapsed"
-                             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
                              SizeChanged="NavigationViewControl_SizeChanged"
                              PaneDisplayMode="LeftMinimal"
 							 IsBackEnabled="False"

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
@@ -8,128 +8,128 @@ using MUXC = Microsoft.UI.Xaml.Controls;
 
 namespace Uno.Gallery
 {
-    public sealed partial class Shell : UserControl
-    {
-        public Shell()
-        {
-            this.InitializeComponent();
+	public sealed partial class Shell : UserControl
+	{
+		public Shell()
+		{
+			this.InitializeComponent();
 
-            InitializeSafeArea();
-            this.Loaded += OnLoaded;
+			InitializeSafeArea();
+			this.Loaded += OnLoaded;
 
-            NestedSampleFrame.RegisterPropertyChangedCallback(ContentControl.ContentProperty, OnNestedSampleFrameChanged);
-            SystemNavigationManager.GetForCurrentView().BackRequested += (s, e) => e.Handled = BackNavigateFromNestedSample();
-        }
+			NestedSampleFrame.RegisterPropertyChangedCallback(ContentControl.ContentProperty, OnNestedSampleFrameChanged);
+			SystemNavigationManager.GetForCurrentView().BackRequested += (s, e) => e.Handled = BackNavigateFromNestedSample();
+		}
 
-        public static Shell GetForCurrentView() => (Shell)Windows.UI.Xaml.Window.Current.Content;
+		public static Shell GetForCurrentView() => (Shell)Windows.UI.Xaml.Window.Current.Content;
 
-        public MUXC.NavigationView NavigationView => NavigationViewControl;
+		public MUXC.NavigationView NavigationView => NavigationViewControl;
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            SetDarkLightToggleInitialState();
-        }
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			SetDarkLightToggleInitialState();
+		}
 
-        private void SetDarkLightToggleInitialState()
-        {
-            // Initialize the toggle to the current theme.
-            var root = global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement;
+		private void SetDarkLightToggleInitialState()
+		{
+			// Initialize the toggle to the current theme.
+			var root = global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement;
 
-            switch (root.ActualTheme)
-            {
-                case ElementTheme.Default:
-                    DarkLightModeToggle.IsChecked = SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark;
-                    break;
-                case ElementTheme.Light:
-                    DarkLightModeToggle.IsChecked = false;
-                    break;
-                case ElementTheme.Dark:
-                    DarkLightModeToggle.IsChecked = true;
-                    break;
-            }
-        }
+			switch (root.ActualTheme)
+			{
+				case ElementTheme.Default:
+					DarkLightModeToggle.IsChecked = SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark;
+					break;
+				case ElementTheme.Light:
+					DarkLightModeToggle.IsChecked = false;
+					break;
+				case ElementTheme.Dark:
+					DarkLightModeToggle.IsChecked = true;
+					break;
+			}
+		}
 
-        /// <summary>
-        /// This method handles the top padding for phones like iPhone X.
-        /// </summary>
-        private void InitializeSafeArea()
-        {
-            var full = Windows.UI.Xaml.Window.Current.Bounds;
-            var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+		/// <summary>
+		/// This method handles the top padding for phones like iPhone X.
+		/// </summary>
+		private void InitializeSafeArea()
+		{
+			var full = Windows.UI.Xaml.Window.Current.Bounds;
+			var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
 
-            var topPadding = Math.Abs(full.Top - bounds.Top);
+			var topPadding = Math.Abs(full.Top - bounds.Top);
 
-            if (topPadding > 0)
-            {
-                TopPaddingRow.Height = new GridLength(topPadding);
-            }
-        }
+			if (topPadding > 0)
+			{
+				TopPaddingRow.Height = new GridLength(topPadding);
+			}
+		}
 
-        private void ToggleButton_Click(object sender, RoutedEventArgs e)
-        {
-            // Set theme for window root.
-            if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
-            {
-                switch (root.ActualTheme)
-                {
-                    case ElementTheme.Default:
-                        if (SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark)
-                        {
-                            root.RequestedTheme = ElementTheme.Light;
-                        }
-                        else
-                        {
-                            root.RequestedTheme = ElementTheme.Dark;
-                        }
-                        break;
-                    case ElementTheme.Light:
-                        root.RequestedTheme = ElementTheme.Dark;
-                        break;
-                    case ElementTheme.Dark:
-                        root.RequestedTheme = ElementTheme.Light;
-                        break;
-                }
-            }
-        }
+		private void ToggleButton_Click(object sender, RoutedEventArgs e)
+		{
+			// Set theme for window root.
+			if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+			{
+				switch (root.ActualTheme)
+				{
+					case ElementTheme.Default:
+						if (SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark)
+						{
+							root.RequestedTheme = ElementTheme.Light;
+						}
+						else
+						{
+							root.RequestedTheme = ElementTheme.Dark;
+						}
+						break;
+					case ElementTheme.Light:
+						root.RequestedTheme = ElementTheme.Dark;
+						break;
+					case ElementTheme.Dark:
+						root.RequestedTheme = ElementTheme.Light;
+						break;
+				}
+			}
+		}
 
-        private void OnNestedSampleFrameChanged(DependencyObject sender, DependencyProperty dp)
-        {
-            var isInsideNestedSample = NestedSampleFrame.Content != null;
+		private void OnNestedSampleFrameChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			var isInsideNestedSample = NestedSampleFrame.Content != null;
 
-            // prevent empty frame from blocking the content (nav-view) behind it
-            NestedSampleFrame.Visibility = isInsideNestedSample
-                ? Visibility.Visible
-                : Visibility.Collapsed;
+			// prevent empty frame from blocking the content (nav-view) behind it
+			NestedSampleFrame.Visibility = isInsideNestedSample
+				? Visibility.Visible
+				: Visibility.Collapsed;
 
-            // toggle built-in back button for wasm (from browser) and uwp (on title bar)
-            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
-                ? AppViewBackButtonVisibility.Visible
-                : AppViewBackButtonVisibility.Collapsed;
-        }
+			// toggle built-in back button for wasm (from browser) and uwp (on title bar)
+			SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
+				? AppViewBackButtonVisibility.Visible
+				: AppViewBackButtonVisibility.Collapsed;
+		}
 
-        public void ShowNestedSample<TPage>(bool? clearStack = null) where TPage : Page
-        {
-            var wasFrameEmpty = NestedSampleFrame.Content == null;
-            if (NestedSampleFrame.Navigate(typeof(TPage)) && (clearStack ?? wasFrameEmpty))
-            {
-                NestedSampleFrame.BackStack.Clear();
-            }
-        }
+		public void ShowNestedSample<TPage>(bool? clearStack = null) where TPage : Page
+		{
+			var wasFrameEmpty = NestedSampleFrame.Content == null;
+			if (NestedSampleFrame.Navigate(typeof(TPage)) && (clearStack ?? wasFrameEmpty))
+			{
+				NestedSampleFrame.BackStack.Clear();
+			}
+		}
 
-        public bool BackNavigateFromNestedSample()
-        {
-            if (NestedSampleFrame.Content == null)
-            {
-                return false;
-            }
+		public bool BackNavigateFromNestedSample()
+		{
+			if (NestedSampleFrame.Content == null)
+			{
+				return false;
+			}
 
-            if (NestedSampleFrame.CanGoBack)
-            {
-                NestedSampleFrame.GoBack();
-            }
-            else
-            {
-                NestedSampleFrame.Content = null;
+			if (NestedSampleFrame.CanGoBack)
+			{
+				NestedSampleFrame.GoBack();
+			}
+			else
+			{
+				NestedSampleFrame.Content = null;
 
 #if __IOS__
 				// This will force reset the UINavigationController, to prevent the back button from appearing when the stack is supposely empty.
@@ -139,38 +139,38 @@ namespace Uno.Gallery
 				NestedSampleFrame.BackStack.Add(default);
 				NestedSampleFrame.BackStack.Clear();
 #endif
-            }
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        private void NavViewToggleButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
-            {
-                NavigationViewControl.IsPaneOpen = !NavigationViewControl.IsPaneOpen;
-            }
-            else if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.Left)
-            {
-                NavigationViewControl.IsPaneVisible = !NavigationViewControl.IsPaneVisible;
-                NavigationViewControl.IsPaneOpen = NavigationViewControl.IsPaneVisible;
-            }
-        }
+		private void NavViewToggleButton_Click(object sender, RoutedEventArgs e)
+		{
+			if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
+			{
+				NavigationViewControl.IsPaneOpen = !NavigationViewControl.IsPaneOpen;
+			}
+			else if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.Left)
+			{
+				NavigationViewControl.IsPaneVisible = !NavigationViewControl.IsPaneVisible;
+				NavigationViewControl.IsPaneOpen = NavigationViewControl.IsPaneVisible;
+			}
+		}
 
-        private void NavigationViewControl_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            // This could be done using VisualState with Adaptive triggers, but an issue prevents this currently - https://github.com/unoplatform/uno/issues/5168
-            var desktopWidth = (double)Application.Current.Resources["DesktopAdaptiveThresholdWidth"];
-            if (e.NewSize.Width >= desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.Left)
-            {
-                NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left;
-                NavigationViewControl.IsPaneOpen = true;
-            }
-            else if (e.NewSize.Width < desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
-            {
-                NavigationViewControl.IsPaneVisible = true;
-                NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
-            }
-        }
-    }
+		private void NavigationViewControl_SizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			// This could be done using VisualState with Adaptive triggers, but an issue prevents this currently - https://github.com/unoplatform/uno/issues/5168
+			var desktopWidth = (double)Application.Current.Resources["DesktopAdaptiveThresholdWidth"];
+			if (e.NewSize.Width >= desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.Left)
+			{
+				NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left;
+				NavigationViewControl.IsPaneOpen = true;
+			}
+			else if (e.NewSize.Width < desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
+			{
+				NavigationViewControl.IsPaneVisible = true;
+				NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
+			}
+		}
+	}
 }

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
@@ -1,149 +1,135 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using Windows.ApplicationModel.Core;
-using Windows.Devices.Input;
-using Windows.Gaming.Input;
-using Windows.System;
-using Windows.System.Profile;
-using Windows.UI.ViewManagement;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-using Windows.Foundation.Metadata;
-using Windows.UI;
 using Uno.Gallery.Helpers;
 using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using MUXC = Microsoft.UI.Xaml.Controls;
 
 namespace Uno.Gallery
 {
-	public sealed partial class Shell : UserControl
-	{
-		public Shell()
-		{
-			this.InitializeComponent();
+    public sealed partial class Shell : UserControl
+    {
+        public Shell()
+        {
+            this.InitializeComponent();
 
-			InitializeSafeArea();
-			this.Loaded += OnLoaded;
+            InitializeSafeArea();
+            this.Loaded += OnLoaded;
 
-			NestedSampleFrame.RegisterPropertyChangedCallback(ContentControl.ContentProperty, OnNestedSampleFrameChanged);
-			SystemNavigationManager.GetForCurrentView().BackRequested += (s, e) => e.Handled = BackNavigateFromNestedSample();
-		}
+            NestedSampleFrame.RegisterPropertyChangedCallback(ContentControl.ContentProperty, OnNestedSampleFrameChanged);
+            SystemNavigationManager.GetForCurrentView().BackRequested += (s, e) => e.Handled = BackNavigateFromNestedSample();
+        }
 
-		public static Shell GetForCurrentView() => (Shell)Windows.UI.Xaml.Window.Current.Content;
+        public static Shell GetForCurrentView() => (Shell)Windows.UI.Xaml.Window.Current.Content;
 
-		public MUXC.NavigationView NavigationView => NavigationViewControl;
+        public MUXC.NavigationView NavigationView => NavigationViewControl;
 
-		private void OnLoaded(object sender, RoutedEventArgs e)
-		{
-			SetDarkLightToggleInitialState();
-		}
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            SetDarkLightToggleInitialState();
+        }
 
-		private void SetDarkLightToggleInitialState()
-		{
-			// Initialize the toggle to the current theme.
-			var root = global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement;
+        private void SetDarkLightToggleInitialState()
+        {
+            // Initialize the toggle to the current theme.
+            var root = global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement;
 
-			switch (root.ActualTheme)
-			{
-				case ElementTheme.Default:
-					DarkLightModeToggle.IsChecked = SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark;
-					break;
-				case ElementTheme.Light:
-					DarkLightModeToggle.IsChecked = false;
-					break;
-				case ElementTheme.Dark:
-					DarkLightModeToggle.IsChecked = true;
-					break;
-			}
-		}
+            switch (root.ActualTheme)
+            {
+                case ElementTheme.Default:
+                    DarkLightModeToggle.IsChecked = SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark;
+                    break;
+                case ElementTheme.Light:
+                    DarkLightModeToggle.IsChecked = false;
+                    break;
+                case ElementTheme.Dark:
+                    DarkLightModeToggle.IsChecked = true;
+                    break;
+            }
+        }
 
-		/// <summary>
-		/// This method handles the top padding for phones like iPhone X.
-		/// </summary>
-		private void InitializeSafeArea()
-		{
-			var full = Windows.UI.Xaml.Window.Current.Bounds;
-			var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+        /// <summary>
+        /// This method handles the top padding for phones like iPhone X.
+        /// </summary>
+        private void InitializeSafeArea()
+        {
+            var full = Windows.UI.Xaml.Window.Current.Bounds;
+            var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
 
-			var topPadding = Math.Abs(full.Top - bounds.Top);
+            var topPadding = Math.Abs(full.Top - bounds.Top);
 
-			if (topPadding > 0)
-			{
-				TopPaddingRow.Height = new GridLength(topPadding);
-			}
-		}
+            if (topPadding > 0)
+            {
+                TopPaddingRow.Height = new GridLength(topPadding);
+            }
+        }
 
-		private void ToggleButton_Click(object sender, RoutedEventArgs e)
-		{
-			// Set theme for window root.
-			if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
-			{
-				switch (root.ActualTheme)
-				{
-					case ElementTheme.Default:
-						if(SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark)
-						{
-							root.RequestedTheme = ElementTheme.Light;
-						}
-						else
-						{
-							root.RequestedTheme = ElementTheme.Dark;
-						}
-						break;
-					case ElementTheme.Light:
-						root.RequestedTheme = ElementTheme.Dark;
-						break;
-					case ElementTheme.Dark:
-						root.RequestedTheme = ElementTheme.Light;
-						break;
-				}
-			}
-		}
+        private void ToggleButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Set theme for window root.
+            if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+            {
+                switch (root.ActualTheme)
+                {
+                    case ElementTheme.Default:
+                        if (SystemThemeHelper.GetSystemApplicationTheme() == ApplicationTheme.Dark)
+                        {
+                            root.RequestedTheme = ElementTheme.Light;
+                        }
+                        else
+                        {
+                            root.RequestedTheme = ElementTheme.Dark;
+                        }
+                        break;
+                    case ElementTheme.Light:
+                        root.RequestedTheme = ElementTheme.Dark;
+                        break;
+                    case ElementTheme.Dark:
+                        root.RequestedTheme = ElementTheme.Light;
+                        break;
+                }
+            }
+        }
 
-		private void OnNestedSampleFrameChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			var isInsideNestedSample = NestedSampleFrame.Content != null;
+        private void OnNestedSampleFrameChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            var isInsideNestedSample = NestedSampleFrame.Content != null;
 
-			// prevent empty frame from blocking the content (nav-view) behind it
-			NestedSampleFrame.Visibility = isInsideNestedSample
-				? Visibility.Visible
-				: Visibility.Collapsed;
+            // prevent empty frame from blocking the content (nav-view) behind it
+            NestedSampleFrame.Visibility = isInsideNestedSample
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
-			// toggle built-in back button for wasm (from browser) and uwp (on title bar)
-			SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
-				? AppViewBackButtonVisibility.Visible
-				: AppViewBackButtonVisibility.Collapsed;
-		}
+            // toggle built-in back button for wasm (from browser) and uwp (on title bar)
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
+                ? AppViewBackButtonVisibility.Visible
+                : AppViewBackButtonVisibility.Collapsed;
+        }
 
-		public void ShowNestedSample<TPage>(bool? clearStack = null) where TPage : Page
-		{
-			var wasFrameEmpty = NestedSampleFrame.Content == null;
-			if (NestedSampleFrame.Navigate(typeof(TPage)) && (clearStack ?? wasFrameEmpty))
-			{
-				NestedSampleFrame.BackStack.Clear();
-			}
-		}
+        public void ShowNestedSample<TPage>(bool? clearStack = null) where TPage : Page
+        {
+            var wasFrameEmpty = NestedSampleFrame.Content == null;
+            if (NestedSampleFrame.Navigate(typeof(TPage)) && (clearStack ?? wasFrameEmpty))
+            {
+                NestedSampleFrame.BackStack.Clear();
+            }
+        }
 
-		public bool BackNavigateFromNestedSample()
-		{
-			if (NestedSampleFrame.Content == null)
-			{
-				return false;
-			}
+        public bool BackNavigateFromNestedSample()
+        {
+            if (NestedSampleFrame.Content == null)
+            {
+                return false;
+            }
 
-			if (NestedSampleFrame.CanGoBack)
-			{
-				NestedSampleFrame.GoBack();
-			}
-			else
-			{
-				NestedSampleFrame.Content = null;
+            if (NestedSampleFrame.CanGoBack)
+            {
+                NestedSampleFrame.GoBack();
+            }
+            else
+            {
+                NestedSampleFrame.Content = null;
 
 #if __IOS__
 				// This will force reset the UINavigationController, to prevent the back button from appearing when the stack is supposely empty.
@@ -153,9 +139,54 @@ namespace Uno.Gallery
 				NestedSampleFrame.BackStack.Add(default);
 				NestedSampleFrame.BackStack.Clear();
 #endif
-			}
+            }
 
-			return true;
-		}
-	}
+            return true;
+        }
+
+        private void NavigationViewControl_DisplayModeChanged(MUXC.NavigationView sender, MUXC.NavigationViewDisplayModeChangedEventArgs args)
+        {
+            MUXC.NavigationViewPaneDisplayMode targetMode;
+            if (args.DisplayMode == MUXC.NavigationViewDisplayMode.Minimal)
+            {
+                sender.IsPaneVisible = true;
+                targetMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
+            }
+            else
+            {
+                targetMode = MUXC.NavigationViewPaneDisplayMode.Left;
+                sender.IsPaneOpen = true;
+            }
+            if (sender.PaneDisplayMode != targetMode)
+            {
+                sender.PaneDisplayMode = targetMode;
+            }
+        }
+
+        private void NavViewToggleButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
+            {
+                NavigationViewControl.IsPaneOpen = !NavigationViewControl.IsPaneOpen;
+            }
+            else if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.Left)
+            {
+                NavigationViewControl.IsPaneVisible = !NavigationViewControl.IsPaneVisible;
+                NavigationViewControl.IsPaneOpen = NavigationViewControl.IsPaneVisible;
+            }
+        }
+
+        private void NavigationViewControl_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            var desktopWidth = (double)Application.Current.Resources["DesktopAdaptiveThresholdWidth"];
+            if (e.NewSize.Width >= desktopWidth)
+            {
+                NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left;
+            }
+            else
+            {
+                NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
+            }
+        }
+    }
 }

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
@@ -144,25 +144,6 @@ namespace Uno.Gallery
             return true;
         }
 
-        private void NavigationViewControl_DisplayModeChanged(MUXC.NavigationView sender, MUXC.NavigationViewDisplayModeChangedEventArgs args)
-        {
-            MUXC.NavigationViewPaneDisplayMode targetMode;
-            if (args.DisplayMode == MUXC.NavigationViewDisplayMode.Minimal)
-            {
-                sender.IsPaneVisible = true;
-                targetMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
-            }
-            else
-            {
-                targetMode = MUXC.NavigationViewPaneDisplayMode.Left;
-                sender.IsPaneOpen = true;
-            }
-            if (sender.PaneDisplayMode != targetMode)
-            {
-                sender.PaneDisplayMode = targetMode;
-            }
-        }
-
         private void NavViewToggleButton_Click(object sender, RoutedEventArgs e)
         {
             if (NavigationViewControl.PaneDisplayMode == MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
@@ -178,13 +159,16 @@ namespace Uno.Gallery
 
         private void NavigationViewControl_SizeChanged(object sender, SizeChangedEventArgs e)
         {
+            // This could be done using VisualState with Adaptive triggers, but an issue prevents this currently - https://github.com/unoplatform/uno/issues/5168
             var desktopWidth = (double)Application.Current.Resources["DesktopAdaptiveThresholdWidth"];
-            if (e.NewSize.Width >= desktopWidth)
+            if (e.NewSize.Width >= desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.Left)
             {
                 NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left;
+                NavigationViewControl.IsPaneOpen = true;
             }
-            else
+            else if (e.NewSize.Width < desktopWidth && NavigationViewControl.PaneDisplayMode != MUXC.NavigationViewPaneDisplayMode.LeftMinimal)
             {
+                NavigationViewControl.IsPaneVisible = true;
                 NavigationViewControl.PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal;
             }
         }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5143, fixes https://github.com/unoplatform/Uno.Gallery/issues/131, fixes #135

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

CompactMode looks off.

## What is the new behavior?

Disabled the NavigationView compact mode by forcing the pane open and hiding the toggle button in expanded mode.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)