### PR TITLE
fix(macOS): NVI PointerOver state being stuck

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/NavigationView.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/NavigationView.xaml
@@ -307,7 +307,7 @@
 
 	<x:Double x:Key="NavigationViewItemBackgroundPointerOverOpacity">0.12</x:Double>
 	<!-- the Pressed state will have a Ripple to make it more darker, so we are using the same value as PointerOver -->
-	<x:Double x:Key="NavigationViewItemBackgroundPressedOpacity">0.12</x:Double>
+	<x:Double x:Key="NavigationViewItemBackgroundPressedOpacity">0.24</x:Double>
 
 	<!-- NavigationView -->
 	<StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="MaterialSurfaceBrush" />
@@ -1646,13 +1646,6 @@
 						<Border x:Name="RevealBorder"
 								BorderBrush="{TemplateBinding BorderBrush}"
 								BorderThickness="{TemplateBinding BorderThickness}" />
-						<Border Margin="{TemplateBinding Padding}">
-							<!-- dont apply Margin on Ripple, as it will be applied twice (on the Ripple and on its template root) -->
-							<!-- material#446: skia:Opacity to workaround Ripple opacity issue -->
-							<material:Ripple Feedback="{StaticResource NavigationViewRippleFeedback}"
-											 skia:Opacity="0.12"
-											 CornerRadius="{TemplateBinding CornerRadius}" />
-						</Border>
 
 						<!-- disabled hit-test because we dont want the content or the chevron to block the click event -->
 						<!-- as the ripple above would need it to play its effect -->


### PR DESCRIPTION
GitHub Issue (If applicable): resolved: #118, re: unoplatform/uno.material#449

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

fixes NVI would sometimes get stuck in selected/pointer-over states.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

## Other information
The `Ripple` control has been identified as the source of these issues. Removing it for now until it gets fixed or when we have a better way to implement that effect.