### PR TITLE
chore: Disable WinUI ProgressRing Samples for Skia

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ProgressSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ProgressSamplePage.xaml
@@ -18,6 +18,7 @@
 
 						<not_skia:Border>
 						<!-- ProgressRing -->
+						<!-- skia: ProgressRing uses Lottie which isnt supported on skia yet -->
 							<smtx:XamlDisplay UniqueKey="ProgressSamplePage_Fluent"
 											  smtx:XamlDisplayExtensions.Header="ProgressRing">
 

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ProgressSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ProgressSamplePage.xaml
@@ -6,6 +6,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:not_skia="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -15,13 +16,15 @@
 				<DataTemplate>
 					<StackPanel>
 
+						<not_skia:Border>
 						<!-- ProgressRing -->
-						<smtx:XamlDisplay UniqueKey="ProgressSamplePage_Fluent"
-										  smtx:XamlDisplayExtensions.Header="ProgressRing">
+							<smtx:XamlDisplay UniqueKey="ProgressSamplePage_Fluent"
+											  smtx:XamlDisplayExtensions.Header="ProgressRing">
 
-							<winui:ProgressRing IsActive="True"
-												HorizontalAlignment="Left" />
-						</smtx:XamlDisplay>
+								<winui:ProgressRing IsActive="True"
+													HorizontalAlignment="Left" />
+							</smtx:XamlDisplay>
+						</not_skia:Border>
 
 						<!-- ProgressBar -->
 						<smtx:XamlDisplay UniqueKey="ProgressSamplePage_Fluent_ProgressBar"


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Skia Fluent sample for ProgressBar/Ring is blank

## What is the new behavior?

Skia Fluent sample for ProgressBar/Ring is not blank


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
