### PR TITLE
fix: ExpandingBottomSheet page layout

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ExpandingBottomSheetSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ExpandingBottomSheetSamplePage.xaml
@@ -9,20 +9,23 @@
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<local:SamplePageLayout>
-
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+			
+		<local:SamplePageLayout Grid.Row="0">
 			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>
-						<TextBlock 
-                        Text="Try out the sheet in the bottom right corner of the window" 
-						Style="{StaticResource MaterialBody1}"
-						Foreground="{StaticResource MaterialOnBackgroundBrush}"
-						Opacity="0.8"
-						Margin="0,8,0,0" />
+						<TextBlock Text="Try out the sheet in the bottom right corner of the window"
+								   Style="{StaticResource MaterialBody1}"
+								   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+								   Opacity="0.8"
+								   Margin="0,8,0,0" />
 						<smtx:XamlPresenter ReferenceKey="ExpandingBottomSheetSamplePage_Content"
-										HorizontalAlignment="Stretch"
-										VerticalAlignment="Center" />
+											HorizontalAlignment="Stretch"
+											VerticalAlignment="Center" />
 					</StackPanel>
 				</DataTemplate>
 			</local:SamplePageLayout.MaterialTemplate>
@@ -30,6 +33,7 @@
 
 		<!-- Minimal BottomSheet Toggle -->
 		<ToggleSwitch x:Name="ToggleBottomSheet"
+					  Grid.Row="1"
 					  Header="Toggle Minimal Sheet"
 					  Style="{StaticResource MaterialToggleSwitchStyle}"
 					  HorizontalAlignment="Left"
@@ -37,6 +41,7 @@
 					  Margin="24,4" />
 
 		<smtx:XamlDisplay UniqueKey="ExpandingBottomSheetSamplePage_Content"
+						  Grid.RowSpan="2"
 						  Style="{StaticResource ContentOnlyXamlDisplayStyle}"
 						  Margin="0"
 						  Padding="0">


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno#5180

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
The xaml source is no longer displayed underneath the toggle button.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

## Other information
