### PR TITLE
fix(welcome-bot): link for swag form

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -16,7 +16,7 @@
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  Congrats on your first pull-request! We ❤ the people who are involved in this project, and we’d love to pay it forward by [sending you some swag](https://forms.office.com/Pages/ResponsePage.aspx?id=Ye9TbdG2UEGuC0O5DnXgzai0HkTgxONNjPmzuZ5zgdRUQzFJMVBPSU8xWDBUUlNOTExCWFUwQjNBNy4u). If you have any feedback (or ideas how to improve Uno as a open-source project) please [open a feedback issue](https://github.com/unoplatform/uno/issues/new?labels=kind%2Ffeedback%2C+triage%2Funtriaged&template=feedback.md).
+  Congrats on your first pull-request! We ❤ the people who are involved in this project, and we’d love to pay it forward by [sending you some swag](https://forms.office.com/Pages/ResponsePage.aspx?id=Ye9TbdG2UEGuC0O5DnXgzcxnnVo6zspHjmNPgM3UO41UNFpFU01TV1UxU0FWRTNMNFJUTlBLMjhIWi4u). If you have any feedback (or ideas how to improve Uno as a open-source project) please [open a feedback issue](https://github.com/unoplatform/uno/issues/new?labels=kind%2Ffeedback%2C+triage%2Funtriaged&template=feedback.md).
   <br>
   ![giphy](https://user-images.githubusercontent.com/127353/66220548-37ae4d00-e69b-11e9-8a16-f08f87b3b27c.gif)
   <br>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/private/issues/214

## PR Type

What kind of change does this PR introduce?

- Documentation content changes
- Project automation

## What is the new behavior?

fixed dead link in the WelcomeBot message for new contributor