### PR TITLE
fix: Make Design RadioButton list scrollable

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
@@ -109,102 +109,106 @@
 													  Content="{TemplateBinding Content}"
 													  ContentTemplate="{TemplateBinding HeaderTemplate}" />
 
-									<StackPanel x:Name="PART_ScrollingTabs"
-												HorizontalAlignment="Stretch"
-												BorderBrush="{TemplateBinding BorderBrush}"
-												BorderThickness="0,0,0,1"
-												Orientation="Horizontal">
+									<ScrollViewer HorizontalScrollMode="Enabled"
+												  HorizontalScrollBarVisibility="Hidden"
+												  VerticalScrollBarVisibility="Hidden"
+												  VerticalScrollMode="Disabled">
+										<StackPanel x:Name="PART_ScrollingTabs"
+													HorizontalAlignment="Stretch"
+													BorderBrush="{TemplateBinding BorderBrush}"
+													BorderThickness="0,0,0,1"
+													Orientation="Horizontal">
 
-										<!-- Material RadioButton -->
-										<RadioButton x:Name="PART_MaterialRadioButton"
-													 Margin="0,0,16,0"
-													 AutomationProperties.AutomationId="PART_MaterialRadioButton"
-													 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-													 Visibility="Collapsed">
-											<StackPanel Orientation="Horizontal">
+											<!-- Material RadioButton -->
+											<RadioButton x:Name="PART_MaterialRadioButton"
+														 Margin="0,0,16,0"
+														 AutomationProperties.AutomationId="PART_MaterialRadioButton"
+														 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+														 Visibility="Collapsed">
+												<StackPanel Orientation="Horizontal">
 
-												<!-- Label -->
-												<TextBlock Style="{StaticResource MaterialHeadline6}"
-														   Text="Material" />
+													<!-- Label -->
+													<TextBlock Style="{StaticResource MaterialHeadline6}"
+															   Text="Material" />
 
-												<!-- Icon -->
-												<Image Width="16"
-													   Height="16"
-													   Margin="10,0,0,0"
-													   VerticalAlignment="Center"
-													   Source="ms-appx:///Assets/MaterialIcon_Small.png"
-													   Stretch="UniformToFill" />
-											</StackPanel>
-										</RadioButton>
+													<!-- Icon -->
+													<Image Width="16"
+														   Height="16"
+														   Margin="10,0,0,0"
+														   VerticalAlignment="Center"
+														   Source="ms-appx:///Assets/MaterialIcon_Small.png"
+														   Stretch="UniformToFill" />
+												</StackPanel>
+											</RadioButton>
 
-										<!-- Fluent RadioButton -->
-										<RadioButton x:Name="PART_FluentRadioButton"
-													 Margin="0,0,16,0"
-													 AutomationProperties.AutomationId="PART_FluentRadioButton"
-													 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-													 Visibility="Collapsed">
-											<StackPanel Orientation="Horizontal">
+											<!-- Fluent RadioButton -->
+											<RadioButton x:Name="PART_FluentRadioButton"
+														 Margin="0,0,16,0"
+														 AutomationProperties.AutomationId="PART_FluentRadioButton"
+														 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+														 Visibility="Collapsed">
+												<StackPanel Orientation="Horizontal">
 
-												<!-- Label -->
-												<TextBlock Style="{StaticResource MaterialHeadline6}"
-														   Text="Fluent" />
+													<!-- Label -->
+													<TextBlock Style="{StaticResource MaterialHeadline6}"
+															   Text="Fluent" />
 
-												<!-- Icon -->
-												<Image Width="16"
-													   Height="16"
-													   Margin="10,0,0,0"
-													   VerticalAlignment="Center"
-													   Source="ms-appx:///Assets/FluentIcon_Small.png"
-													   Stretch="UniformToFill" />
-											</StackPanel>
-										</RadioButton>
+													<!-- Icon -->
+													<Image Width="16"
+														   Height="16"
+														   Margin="10,0,0,0"
+														   VerticalAlignment="Center"
+														   Source="ms-appx:///Assets/FluentIcon_Small.png"
+														   Stretch="UniformToFill" />
+												</StackPanel>
+											</RadioButton>
 
-										<!-- Cupertino RadioButton -->
-										<RadioButton x:Name="PART_CupertinoRadioButton"
-													 Margin="0,0,16,0"
-													 AutomationProperties.AutomationId="PART_CupertinoRadioButton"
-													 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-													 Visibility="Collapsed">
-											<StackPanel Orientation="Horizontal">
+											<!-- Cupertino RadioButton -->
+											<RadioButton x:Name="PART_CupertinoRadioButton"
+														 Margin="0,0,16,0"
+														 AutomationProperties.AutomationId="PART_CupertinoRadioButton"
+														 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+														 Visibility="Collapsed">
+												<StackPanel Orientation="Horizontal">
 
-												<!-- Label -->
-												<TextBlock Style="{StaticResource MaterialHeadline6}"
-														   Text="Cupertino" />
+													<!-- Label -->
+													<TextBlock Style="{StaticResource MaterialHeadline6}"
+															   Text="Cupertino" />
 
-												<!-- Icon -->
-												<Image Width="16"
-													   Height="16"
-													   Margin="10,0,0,0"
-													   VerticalAlignment="Center"
-													   Source="ms-appx:///Assets/AppleIcon_Small.png"
-													   Stretch="UniformToFill" />
-											</StackPanel>
-										</RadioButton>
+													<!-- Icon -->
+													<Image Width="16"
+														   Height="16"
+														   Margin="10,0,0,0"
+														   VerticalAlignment="Center"
+														   Source="ms-appx:///Assets/AppleIcon_Small.png"
+														   Stretch="UniformToFill" />
+												</StackPanel>
+											</RadioButton>
 
-										<!-- Native RadioButton -->
-										<RadioButton x:Name="PART_NativeRadioButton"
-													 Margin="0,0,16,0"
-													 AutomationProperties.AutomationId="PART_NativeRadioButton"
-													 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-													 Visibility="Collapsed">
-											<StackPanel Orientation="Horizontal">
+											<!-- Native RadioButton -->
+											<RadioButton x:Name="PART_NativeRadioButton"
+														 Margin="0,0,16,0"
+														 AutomationProperties.AutomationId="PART_NativeRadioButton"
+														 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+														 Visibility="Collapsed">
+												<StackPanel Orientation="Horizontal">
 
-												<!-- Label -->
-												<TextBlock Style="{StaticResource MaterialHeadline6}"
-														   Text="Native" />
+													<!-- Label -->
+													<TextBlock Style="{StaticResource MaterialHeadline6}"
+															   Text="Native" />
 
-												<!-- Icon -->
-												<Image Width="16"
-													   Height="16"
-													   Margin="10,0,0,0"
-													   VerticalAlignment="Center"
-													   android:Source="ms-appx:///Assets/AndroidIcon_Small.png"
-													   not_android:Source="ms-appx:///Assets/AppleIcon_Small.png"
-													   Stretch="UniformToFill" />
-											</StackPanel>
-										</RadioButton>
-									</StackPanel>
-
+													<!-- Icon -->
+													<Image Width="16"
+														   Height="16"
+														   Margin="10,0,0,0"
+														   VerticalAlignment="Center"
+														   android:Source="ms-appx:///Assets/AndroidIcon_Small.png"
+														   not_android:Source="ms-appx:///Assets/AppleIcon_Small.png"
+														   Stretch="UniformToFill" />
+												</StackPanel>
+											</RadioButton>
+										</StackPanel>
+									</ScrollViewer>
 									<Grid>
 
 										<!-- Material Content -->
@@ -266,112 +270,115 @@
 						</ScrollViewer>
 
 						<!-- Separator line that becomes hidden by the sticky tabs when scrolled enough -->
-						<Rectangle x:Name="MobileTopBarSeparator"
-								   Grid.Row="1"
-								   Height="1"
-								   HorizontalAlignment="Stretch"
-								   VerticalAlignment="Top"
-								   Fill="{StaticResource DividerBrush}"
-								   Visibility="Collapsed" />
+						<StackPanel Grid.Row="1">
+							<ScrollViewer HorizontalScrollMode="Enabled"
+										  HorizontalScrollBarVisibility="Hidden"
+										  VerticalScrollBarVisibility="Hidden"
+										  VerticalScrollMode="Disabled">
+								<!-- This is the sticky tabs that appear when we scroll enough. -->
+								<StackPanel x:Name="PART_StickyTabs"
+											Margin="48,0"
+											HorizontalAlignment="Stretch"
+											VerticalAlignment="Top"
+											Background="{StaticResource MaterialBackgroundBrush}"
+											BorderBrush="{TemplateBinding BorderBrush}"
+											BorderThickness="0,0,0,1"
+											Orientation="Horizontal"
+											Visibility="Collapsed">
 
-						<!-- This is the sticky tabs that appear when we scroll enough. -->
-						<StackPanel x:Name="PART_StickyTabs"
-									Grid.Row="1"
-									Margin="48,0"
-									HorizontalAlignment="Stretch"
-									VerticalAlignment="Top"
-									Background="{StaticResource MaterialBackgroundBrush}"
-									BorderBrush="{TemplateBinding BorderBrush}"
-									BorderThickness="0,0,0,1"
-									Orientation="Horizontal"
-									Visibility="Collapsed">
+									<!-- Material RadioButton -->
+									<RadioButton x:Name="PART_StickyMaterialRadioButton"
+												 Margin="0,0,16,0"
+												 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+												 Visibility="Collapsed">
+										<StackPanel Orientation="Horizontal">
 
-							<!-- Material RadioButton -->
-							<RadioButton x:Name="PART_StickyMaterialRadioButton"
-										 Margin="0,0,16,0"
-										 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-										 Visibility="Collapsed">
-								<StackPanel Orientation="Horizontal">
+											<!-- Label -->
+											<TextBlock Style="{StaticResource MaterialHeadline6}"
+													   Text="Material" />
 
-									<!-- Label -->
-									<TextBlock Style="{StaticResource MaterialHeadline6}"
-											   Text="Material" />
+											<!-- Icon -->
+											<Image Width="16"
+												   Height="16"
+												   Margin="10,0,0,0"
+												   VerticalAlignment="Center"
+												   Source="ms-appx:///Assets/MaterialIcon_Small.png"
+												   Stretch="UniformToFill" />
+										</StackPanel>
+									</RadioButton>
 
-									<!-- Icon -->
-									<Image Width="16"
-										   Height="16"
-										   Margin="10,0,0,0"
-										   VerticalAlignment="Center"
-										   Source="ms-appx:///Assets/MaterialIcon_Small.png"
-										   Stretch="UniformToFill" />
+									<!-- Fluent RadioButton -->
+									<RadioButton x:Name="PART_StickyFluentRadioButton"
+												 Margin="0,0,16,0"
+												 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+												 Visibility="Collapsed">
+										<StackPanel Orientation="Horizontal">
+
+											<!-- Label -->
+											<TextBlock Style="{StaticResource MaterialHeadline6}"
+													   Text="Fluent" />
+
+											<!-- Icon -->
+											<Image Width="16"
+												   Height="16"
+												   Margin="10,0,0,0"
+												   VerticalAlignment="Center"
+												   Source="ms-appx:///Assets/FluentIcon_Small.png"
+												   Stretch="UniformToFill" />
+										</StackPanel>
+									</RadioButton>
+
+									<!-- Cupertino RadioButton -->
+									<RadioButton x:Name="PART_StickyCupertinoRadioButton"
+												 Margin="0,0,16,0"
+												 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+												 Visibility="Collapsed">
+										<StackPanel Orientation="Horizontal">
+
+											<!-- Label -->
+											<TextBlock Style="{StaticResource MaterialHeadline6}"
+													   Text="Cupertino" />
+
+											<!-- Icon -->
+											<Image Width="16"
+												   Height="16"
+												   Margin="10,0,0,0"
+												   VerticalAlignment="Center"
+												   Source="ms-appx:///Assets/AppleIcon_Small.png"
+												   Stretch="UniformToFill" />
+										</StackPanel>
+									</RadioButton>
+
+									<!-- Native RadioButton -->
+									<RadioButton x:Name="PART_StickyNativeRadioButton"
+												 Margin="0,0,16,0"
+												 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
+												 Visibility="Collapsed">
+										<StackPanel Orientation="Horizontal">
+
+											<!-- Label -->
+											<TextBlock Style="{StaticResource MaterialHeadline6}"
+													   Text="Native" />
+
+											<!-- Icon -->
+											<Image Width="16"
+												   Height="16"
+												   Margin="10,0,0,0"
+												   VerticalAlignment="Center"
+												   android:Source="ms-appx:///Assets/AndroidIcon_Small.png"
+												   not_android:Source="ms-appx:///Assets/AppleIcon_Small.png"
+												   Stretch="UniformToFill" />
+										</StackPanel>
+									</RadioButton>
 								</StackPanel>
-							</RadioButton>
-
-							<!-- Fluent RadioButton -->
-							<RadioButton x:Name="PART_StickyFluentRadioButton"
-										 Margin="0,0,16,0"
-										 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-										 Visibility="Collapsed">
-								<StackPanel Orientation="Horizontal">
-
-									<!-- Label -->
-									<TextBlock Style="{StaticResource MaterialHeadline6}"
-											   Text="Fluent" />
-
-									<!-- Icon -->
-									<Image Width="16"
-										   Height="16"
-										   Margin="10,0,0,0"
-										   VerticalAlignment="Center"
-										   Source="ms-appx:///Assets/FluentIcon_Small.png"
-										   Stretch="UniformToFill" />
-								</StackPanel>
-							</RadioButton>
-
-							<!-- Cupertino RadioButton -->
-							<RadioButton x:Name="PART_StickyCupertinoRadioButton"
-										 Margin="0,0,16,0"
-										 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-										 Visibility="Collapsed">
-								<StackPanel Orientation="Horizontal">
-
-									<!-- Label -->
-									<TextBlock Style="{StaticResource MaterialHeadline6}"
-											   Text="Cupertino" />
-
-									<!-- Icon -->
-									<Image Width="16"
-										   Height="16"
-										   Margin="10,0,0,0"
-										   VerticalAlignment="Center"
-										   Source="ms-appx:///Assets/AppleIcon_Small.png"
-										   Stretch="UniformToFill" />
-								</StackPanel>
-							</RadioButton>
-
-							<!-- Native RadioButton -->
-							<RadioButton x:Name="PART_StickyNativeRadioButton"
-										 Margin="0,0,16,0"
-										 Style="{StaticResource SampleLayoutModeRadioButtonStyle}"
-										 Visibility="Collapsed">
-								<StackPanel Orientation="Horizontal">
-
-									<!-- Label -->
-									<TextBlock Style="{StaticResource MaterialHeadline6}"
-											   Text="Native" />
-
-									<!-- Icon -->
-									<Image Width="16"
-										   Height="16"
-										   Margin="10,0,0,0"
-										   VerticalAlignment="Center"
-										   android:Source="ms-appx:///Assets/AndroidIcon_Small.png"
-										   not_android:Source="ms-appx:///Assets/AppleIcon_Small.png"
-										   Stretch="UniformToFill" />
-								</StackPanel>
-							</RadioButton>
+							</ScrollViewer>
+							<Rectangle x:Name="MobileTopBarSeparator"
+									   Height="1"
+									   HorizontalAlignment="Stretch"
+									   VerticalAlignment="Top"
+									   Fill="{StaticResource DividerBrush}"
+									   Visibility="Collapsed" />
 						</StackPanel>
-
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="FormFactors">
 								<VisualState x:Name="Desktop">


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/5549

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Native option was cut off and was not selectable

## What is the new behavior?

Can now scroll the list of Design Themes to bring the Native RadioButton into view

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
