### PR TITLE
fix: Address missing styles causing crashes on UWP

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/DatePickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/DatePickerSamplePage.xaml
@@ -59,8 +59,7 @@
 			<local:SamplePageLayout.CupertinoTemplate>
 				<DataTemplate>
 					<StackPanel>
-						<smtx:XamlDisplay Style="{StaticResource XamlDisplayBelowStyle}"
-										  UniqueKey="DatePickerSamplePage_Cupertino_Default"
+						<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Cupertino_Default"
 										  smtx:XamlDisplayExtensions.Header="Default">
 
 							<DatePicker x:Name="myDatePicker2"

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/PasswordBoxSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/PasswordBoxSamplePage.xaml
@@ -75,8 +75,7 @@
 
 						<!-- PasswordBox Outline -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_PasswordBoxSamplePage"
-										  smtx:XamlDisplayExtensions.Header="Default"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Default">
 							<PasswordBox PlaceholderText="Default"
 										 Header="Header"
 										 Style="{StaticResource CupertinoPasswordBoxStyle}" />
@@ -84,8 +83,7 @@
 
 						<!-- PasswordBox Outline Disabled -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_PasswordBoxSamplePage_Disabled"
-										  smtx:XamlDisplayExtensions.Header="Disabled"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Disabled">
 							<PasswordBox PlaceholderText="Disabled"
 										 Style="{StaticResource CupertinoPasswordBoxStyle}"
 										 IsEnabled="False" />

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
@@ -239,43 +239,37 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 					<StackPanel>
 
 						<!-- Large title -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_LargeTitle"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_LargeTitle">
 							<TextBlock Text="Large title"
 									   Style="{StaticResource CupertinoLargeTitle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Title 1 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_PrimaryTitle"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_PrimaryTitle">
 							<TextBlock Text="Title 1"
 									   Style="{StaticResource CupertinoPrimaryTitle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Title 2 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_SecondaryTitle"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_SecondaryTitle">
 							<TextBlock Text="Title 2"
 									   Style="{StaticResource CupertinoSecondaryTitle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Title 3 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_TertiaryTitle"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_TertiaryTitle">
 							<TextBlock Text="Title 3"
 									   Style="{StaticResource CupertinoTertiaryTitle}" />
 						</smtx:XamlDisplay>
 
 						<!-- Headline -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Headline"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Headline">
 							<TextBlock Text="Headline"
 									   Style="{StaticResource CupertinoHeadline}" />
 						</smtx:XamlDisplay>
 
 						<!-- Body -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Body"
-										  Style="{StaticResource XamlDisplayBelowStyle}"
 										  smtx:XamlDisplayExtensions.Header="Body">
 							<TextBlock  Style="{StaticResource CupertinoBody}">
 <TextBlock.Text>
@@ -291,22 +285,19 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 						</smtx:XamlDisplay>
 
 						<!-- Callout -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Callout"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Callout">
 							<TextBlock Text="Callout"
 									   Style="{StaticResource CupertinoCallout}" />
 						</smtx:XamlDisplay>
 
 						<!-- Subhead -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Subhead"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Subhead">
 							<TextBlock Text="Subhead"
 									   Style="{StaticResource CupertinoSubhead}" />
 						</smtx:XamlDisplay>
 
 						<!-- Footnote -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Footnote"
-										  Style="{StaticResource XamlDisplayBelowStyle}"
 										  smtx:XamlDisplayExtensions.Header="Footnote">
 							<TextBlock Style="{StaticResource CupertinoFootnote}">
 <TextBlock.Text>
@@ -323,7 +314,6 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 
 						<!-- Caption 1 -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_PrimaryCaption"
-										  Style="{StaticResource XamlDisplayBelowStyle}"
 										  smtx:XamlDisplayExtensions.Header="Caption 1">
 							<TextBlock Style="{StaticResource CupertinoPrimaryCaption}">
 <TextBlock.Text>
@@ -340,7 +330,6 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 
 						<!-- Caption 2 -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_SecondaryCaption"
-										  Style="{StaticResource XamlDisplayBelowStyle}"
 										  smtx:XamlDisplayExtensions.Header="Caption 2">
 							<TextBlock Style="{StaticResource CupertinoSecondaryCaption}">
 <TextBlock.Text>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBoxSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBoxSamplePage.xaml
@@ -174,16 +174,14 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 
 						<!-- Default Single Line -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBoxSamplePage_DefaultSingleLine"
-										  smtx:XamlDisplayExtensions.Header="Default"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Default">
 							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
 									 PlaceholderText="Placeholder single line" />
 						</smtx:XamlDisplay>
 
 						<!-- Default Multi Line -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBoxSamplePage_DefaultMultiLine"
-										  smtx:XamlDisplayExtensions.Header="Multiline"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Multiline">
 							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
 									 VerticalContentAlignment="Top"
 									 TextWrapping="Wrap"
@@ -203,8 +201,7 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 
 						<!-- Disabled Empty -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBoxSamplePage_DisabledEmpty"
-										  smtx:XamlDisplayExtensions.Header="Disabled (Empty)"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Disabled (Empty)">
 							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
 									 PlaceholderText="Placeholder"
 									 IsEnabled="False" />
@@ -212,8 +209,7 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 
 						<!-- Disabled -->
 						<smtx:XamlDisplay UniqueKey="Cupertino_TextBoxSamplePage_Disabled"
-										  smtx:XamlDisplayExtensions.Header="Disabled"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
+										  smtx:XamlDisplayExtensions.Header="Disabled">
 							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
 									 PlaceholderText="Placeholder"
 									 Text="This is my text"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

TextBox/ComboBox/DatePicker/TextBlock/PasswordBox Cupertino Samples crashing on UWP because of an invalid Style

## What is the new behavior?

Doesn't crash


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
