### PR TITLE
perf: Avoid eagerly formatting the XAML string for ShowMeTheXaml

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
@@ -21,6 +21,8 @@
 				Value="{StaticResource DividerBrush}" />
 		<Setter Property="BorderThickness"
 				Value="1" />
+		<Setter Property="Formatter"
+				Value="{x:Null}" />
 
 		<Setter Property="Template">
 			<Setter.Value>
@@ -94,7 +96,7 @@
 								<!-- Reveal Button -->
 								<ToggleButton x:Name="RevealButton"
 											  Style="{StaticResource XamlDisplayExpandToggleButtonStyle}"
-											  IsChecked="False"
+											  IsChecked="{Binding Path=(smtx:XamlDisplayExtensions.ShowXaml), RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
 											  HorizontalAlignment="Right"
 											  VerticalAlignment="Top"
 											  android:Visibility="Collapsed"
@@ -105,9 +107,9 @@
 							<ScrollViewer Background="{StaticResource SampleSecondBackgroundBrush}"
 										  HorizontalScrollBarVisibility="Auto"
 										  VerticalScrollBarVisibility="Disabled"
-										  win:Visibility="{Binding ElementName=RevealButton, Path=IsChecked, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-										  netstdref:Visibility="{Binding ElementName=RevealButton, Path=IsChecked, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-										  macos:Visibility="{Binding ElementName=RevealButton, Path=IsChecked, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+										  win:Visibility="{Binding Path=(smtx:XamlDisplayExtensions.ShowXaml), RelativeSource={RelativeSource TemplatedParent}}"
+										  netstdref:Visibility="{Binding Path=(smtx:XamlDisplayExtensions.ShowXaml), RelativeSource={RelativeSource TemplatedParent}}"
+										  macos:Visibility="{Binding Path=(smtx:XamlDisplayExtensions.ShowXaml), RelativeSource={RelativeSource TemplatedParent}}"
 										  ios:Visibility="Collapsed"
 										  android:Visibility="Collapsed"
 										  Grid.Row="1">


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Gallery/issues/212\

## PR Type

What kind of change does this PR introduce?
- Perf

## What is the current behavior?

The Xaml string from ShowMeTheXaml is being formatted by the XamlDisplayExtensions on page load for each XamlDisplay element

## What is the new behavior?

Only run formatting logic when displaying the XAML and if the current XAML hasn't been formatted before.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
