### PR TITLE
fix: Only call AnalyticsService for WASM, avoid possible null ref of Dispatcher

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
@@ -41,7 +41,9 @@ namespace Uno.Gallery
 			this.InitializeComponent();
 			this.Suspending += OnSuspending;
 
-			_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunIdleAsync(_ => AnalyticsService.Initialize());
+#if __WASM__
+			_ = Windows.UI.Xaml.Window.Current.Dispatcher?.RunIdleAsync(_ => AnalyticsService.Initialize());
+#endif
 		}
 
 		/// <summary>
@@ -116,7 +118,9 @@ namespace Uno.Gallery
 				var page = (Page)Activator.CreateInstance(sample.ViewType);
 				page.DataContext = sample;
 
+#if __WASM__
 				_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunIdleAsync(_ => AnalyticsService.TrackView(sample?.Title ?? page.GetType().Name));
+#endif
 
 				_shell.NavigationView.Content = page;
 			}


### PR DESCRIPTION

#213
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Null ref occurring on UWP build since Window.Current.Dispatcher is null in the App ctor

## What is the new behavior?

No longer deal with Dispatcher/Analytics calls when not running for WASM


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
