### PR TITLE
fix: Set NotImplementedLogLevel to Debug to avoid unnecessary console logs

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -117,12 +117,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.226" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.318" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -46,9 +46,9 @@
 		</PackageReference>
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />		
-		<PackageReference Include="Uno.UI.Lottie" Version="3.7.0-dev.226" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.7.0-dev.226" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.226" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Lottie" Version="3.7.0-dev.318" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.7.0-dev.318" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.318" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	
 	<Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" />

--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
@@ -44,6 +44,10 @@ namespace Uno.Gallery
 #if __WASM__
 			_ = Windows.UI.Xaml.Window.Current.Dispatcher?.RunIdleAsync(_ => AnalyticsService.Initialize());
 #endif
+
+#if !WINDOWS_UWP
+			Uno.UI.FeatureConfiguration.ApiInformation.NotImplementedLogLevel = LogLevel.Debug; // Raise not implemented usages as Debug messages
+#endif
 		}
 
 		/// <summary>

--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
@@ -35,6 +35,11 @@ namespace Uno.Gallery
 		/// </summary>
 		public App()
 		{
+
+#if !WINDOWS_UWP
+			Uno.UI.FeatureConfiguration.ApiInformation.NotImplementedLogLevel = LogLevel.Debug; // Raise not implemented usages as Debug messages
+#endif
+
 			ConfigureFilters(global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory);
 			ConfigureXamlDisplay();
 
@@ -43,10 +48,6 @@ namespace Uno.Gallery
 
 #if __WASM__
 			_ = Windows.UI.Xaml.Window.Current.Dispatcher?.RunIdleAsync(_ => AnalyticsService.Initialize());
-#endif
-
-#if !WINDOWS_UWP
-			Uno.UI.FeatureConfiguration.ApiInformation.NotImplementedLogLevel = LogLevel.Debug; // Raise not implemented usages as Debug messages
 #endif
 		}
 

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -52,7 +52,7 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -110,9 +110,9 @@
 		<PackageReference Include="Uno.Material" Version="1.0.0-dev.742" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
-		<PackageReference Include="Uno.UI.Lottie" Version="3.7.0-dev.226" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="3.7.0-dev.226" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.226" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Lottie" Version="3.7.0-dev.318" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="3.7.0-dev.318" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.318" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0-dev.45" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0-dev.45" />
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5">

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -220,12 +220,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.226" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.318" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.TestCloud.Agent">

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -115,12 +115,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.7.0-dev.226</Version>
+      <Version>3.7.0-dev.318</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.226" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.7.0-dev.318" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
 Debug logs who flood the console with Not Implemented exceptions

## What is the new behavior?
Console logs are no longer filled with Not Implemented exception messages

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
