### PR TITLE
fix: Workaround for sticky tabs StackPanel measure bug

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
@@ -286,7 +286,7 @@
 						</ScrollViewer>
 
 						<!-- Separator line that becomes hidden by the sticky tabs when scrolled enough -->
-						<StackPanel Grid.Row="1">
+						<StackPanel Grid.Row="1" VerticalAlignment="Top">
 							<ScrollViewer HorizontalScrollMode="Enabled"
 										  HorizontalScrollBarVisibility="Hidden"
 										  VerticalScrollBarVisibility="Hidden"


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/5784

## PR Type

What kind of change does this PR introduce?
- Bugfix

There is currently a bug on macOS that is causing the StackPanel to be arranged to the size of its Grid row even though all of its children are Visbility=Collapsed. This bug should be fixed by the Grid refactor PR (https://github.com/unoplatform/uno/pull/5811). For now, we avoid the StackPanel from Stretching the entire Grid row and intercepting the pointers.

## What is the new behavior?

Pointers are now being handled

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
