### PR TITLE
Fix(ComboBox): Fix the spelling of ComboBox for Uno Gallery

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ComboBoxSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ComboBoxSamplePage.xaml
@@ -76,12 +76,12 @@
 										  Text="Title"
 										  PlaceholderText="Placeholder"
 										  ItemsSource="abcdefghijklmn" />
+								
 								<ComboBox Style="{StaticResource CupertinoComboBoxStyle}"
 										  Text="Title"
-										  PlaceholderText="Disabled ComboBos"
+										  PlaceholderText="Disabled ComboBox"
 										  ItemsSource="abcdefghijklmn"
 										  IsEnabled="False" />
-
 							</StackPanel>
 						</smtx:XamlDisplay>
 					</StackPanel>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/6073

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The spelling of Combobox is incorrect.

## What is the new behavior?

The spelling of Combobox must be correct.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)
