### PR TITLE
Hide section with nested flyouts on mobile devices

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FlyoutSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FlyoutSamplePage.xaml
@@ -1,12 +1,14 @@
-﻿<Page x:Class="Uno.Gallery.Views.Samples.FlyoutSamplePage"
+<Page x:Class="Uno.Gallery.Views.Samples.FlyoutSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Uno.Gallery"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  mc:Ignorable="d">
+	  mc:Ignorable="d android ios">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
@@ -118,7 +120,10 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 						</smtx:XamlDisplay>
 
 						<!-- Material MenuFlyout + MenuFlyoutSubItem -->
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Material_Flyout"
+
+						<smtx:XamlDisplay android:Visibility="Collapsed"
+										  ios:Visibility="Collapsed"
+										  UniqueKey="FlyoutSamplePage_Material_Flyout"
 										  smtx:XamlDisplayExtensions.Header="Nested MenuFlyout">
 
 							<Button Content="Help"
@@ -270,7 +275,10 @@ turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo ha
 							</Button>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Nested_MenuFlyout"
+
+						<smtx:XamlDisplay android:Visibility="Collapsed"
+										  ios:Visibility="Collapsed"
+										  UniqueKey="FlyoutSamplePage_Fluent_Nested_MenuFlyout"
 										  smtx:XamlDisplayExtensions.Header="Nested MenuFlyout">
 
 							<Button Content="Help">


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/5639

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

Currently, we show the a section on all targets containing nested flyouts which are difficult to show correctly on mobile devices due to screen size constraints. 


## What is the new behavior?

Since Google's Material guidelines [imply](https://material.io/components/menus#dropdown-menu) against the use of Cascading menus on Android, there's no native equivalent on iOS, and MenuFlyout is likely built on the Windows UI side now with desktop in mind, it makes sense to only show this section on Windows and WASM.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Fixes https://github.com/unoplatform/uno/issues/5639
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
N/A