### PR TITLE
fix(CalendarView): Separate CalendarView/CalendarDatePicker samples. Fix selection mode combbox

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -108,10 +108,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -120,12 +120,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.439" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.461" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -27,8 +27,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.774" />
-		<PackageReference Include="Uno.Material" Version="1.0.0-dev.774" />
+		<PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.778" />
+		<PackageReference Include="Uno.Material" Version="1.0.0-dev.778" />
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
@@ -46,9 +46,9 @@
 		</PackageReference>
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />		
-		<PackageReference Include="Uno.UI.Lottie" Version="3.8.0-dev.439" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.8.0-dev.439" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.439" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Lottie" Version="3.8.0-dev.461" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="3.8.0-dev.461" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.461" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	
 	<Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" />

--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml
@@ -11,6 +11,13 @@
 				<!-- Load WinUI resources -->
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"/>
 
+				<MaterialColors xmlns="using:Uno.Material"
+								ColorPaletteOverrideSource="ms-appx:///Views/Colors.xaml" />
+				<MaterialResources xmlns="using:Uno.Material" />
+
+				<CupertinoColors xmlns="using:Uno.Cupertino"  />
+				<CupertinoResources xmlns="using:Uno.Cupertino" />
+
 				<ResourceDictionary Source="Views/Converters.xaml" />
 				<ResourceDictionary Source="Views/Fonts.xaml" />
 
@@ -26,6 +33,7 @@
 				<ResourceDictionary Source="Views/Styles/RadioButton.xaml" />
 				<ResourceDictionary Source="Views/Styles/SamplePageLayout.xaml" />
 				<ResourceDictionary Source="Views/Styles/ThreeColorPaletteView.xaml" />
+				<ResourceDictionary Source="Views/Styles/TextBlock.xaml" />
 				<ResourceDictionary Source="Views/Styles/ToggleButton.xaml" />
 				<ResourceDictionary Source="Views/Styles/ToggleSwitch.xaml" />
 				<ResourceDictionary Source="Views/Styles/XamlDisplay.xaml" />

--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml.cs
@@ -85,8 +85,6 @@ namespace Uno.Gallery
 				Xamarin.Calabash.Start();
 #endif
 
-				InitializeThemes();
-
 #if WINDOWS_UWP
 				ApplicationView.GetForCurrentView().SetPreferredMinSize(new Size(320, 568)); // (size of the iPhone SE)
 #endif
@@ -356,13 +354,5 @@ namespace Uno.Gallery
 				.Where(x => x.SamplePageAttribute != null)
 				.Select(x => new Sample(x.SamplePageAttribute, x.TypeInfo.AsType()))
 				.ToArray();
-
-
-		private void InitializeThemes()
-		{
-			Material.Resources.Init(this, colorPaletteOverride: new ResourceDictionary() { Source = new Uri("ms-appx:///Views/Colors.xaml") });
-			Cupertino.Resources.Init(this, null);
-			this.Resources.MergedDictionaries.Add(new ResourceDictionary() { Source = new Uri("ms-appx:///Views/Styles/TextBlock.xaml") });
-		}
 	}
 }

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -40,10 +40,10 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="2.3.0" />
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -52,7 +52,7 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
@@ -208,6 +208,9 @@
     </Compile>
     <Compile Include="Views\SamplePages\BottomNavigationBarSamplePage.xaml.cs">
       <DependentUpon>BottomNavigationBarSamplePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SamplePages\CalendarDatePickerSamplePage.xaml.cs">
+      <DependentUpon>CalendarDatePickerSamplePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SamplePages\CalendarViewSamplePage.xaml.cs">
       <DependentUpon>CalendarViewSamplePage.xaml</DependentUpon>
@@ -436,6 +439,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\SamplePages\BottomNavigationBarSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\CalendarDatePickerSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml
@@ -1,0 +1,79 @@
+﻿<Page x:Class="Uno.Gallery.Views.SamplePages.CalendarDatePickerSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Gallery"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+			<local:SamplePageLayout.MaterialTemplate>
+				<DataTemplate>
+					<StackPanel Spacing="20">
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarDatePicker"
+										  smtx:XamlDisplayExtensions.Header="Default">
+							<CalendarDatePicker Header="Date"
+												x:Name="Material_CalendarDatePicker"
+												AutomationProperties.AutomationId="Material_CalendarDatePicker"
+												Style="{StaticResource MaterialCalendarDatePickerStyle}" />
+						</smtx:XamlDisplay>
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarDatePicker_Disabled"
+										  smtx:XamlDisplayExtensions.Header="Disabled">
+							<CalendarDatePicker Header="Date"
+												IsEnabled="False"
+												x:Name="Material_CalendarDatePicker_Disabled"
+												AutomationProperties.AutomationId="Material_CalendarDatePicker_Disabled"
+												Style="{StaticResource MaterialCalendarDatePickerStyle}" />
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.MaterialTemplate>
+			<local:SamplePageLayout.CupertinoTemplate>
+				<DataTemplate>
+
+					<StackPanel Spacing="20">
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarDatePicker"
+										  smtx:XamlDisplayExtensions.Header="Default">
+							<CalendarDatePicker Header="Date"
+												x:Name="Cupertino_CalendarDatePicker"
+												AutomationProperties.AutomationId="Cupertino_CalendarDatePicker"
+												Style="{StaticResource CupertinoCalendarDatePickerStyle}" />
+						</smtx:XamlDisplay>
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarDatePicker_Disabled"
+										  smtx:XamlDisplayExtensions.Header="Disabled">
+							<CalendarDatePicker Header="Date"
+												IsEnabled="False"
+												x:Name="Cupertino_CalendarDatePicker_Disabled"
+												AutomationProperties.AutomationId="Cupertino_CalendarDatePicker_Disabled"
+												Style="{StaticResource CupertinoCalendarDatePickerStyle}" />
+						</smtx:XamlDisplay>
+					</StackPanel>
+
+				</DataTemplate>
+			</local:SamplePageLayout.CupertinoTemplate>
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel Spacing="20">
+
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarDatePicker"
+										  smtx:XamlDisplayExtensions.Header="Default">
+							<CalendarDatePicker Header="Date"
+												x:Name="Fluent_CalendarDatePicker"
+												AutomationProperties.AutomationId="Fluent_CalendarDatePicker" />
+						</smtx:XamlDisplay>
+						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarDatePicker_Disabled"
+										  smtx:XamlDisplayExtensions.Header="Disabled">
+							<CalendarDatePicker Header="Date"
+												IsEnabled="False"
+												x:Name="Fluent_CalendarDatePicker_Disabled"
+												AutomationProperties.AutomationId="Fluent_CalendarDatePicker_Disabled" />
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+		</local:SamplePageLayout>
+	</Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.Gallery.Views.SamplePages
+{
+	[SamplePage(SampleCategory.Components, "CalendarDatePicker", Description = "Represents a control that allows a user to pick a date from a calendar display.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.calendardatepicker")]
+	public sealed partial class CalendarDatePickerSamplePage : Page
+	{
+		public CalendarDatePickerSamplePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
@@ -12,101 +12,72 @@
 		<local:SamplePageLayout>
 			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
-					<StackPanel Spacing="20">
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarView"
-										  smtx:XamlDisplayExtensions.Header="CalendarView"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<StackPanel Spacing="20">
-								<TextBlock Text="Selection Mode:"
-										   Style="{StaticResource MaterialBody1}" />
-								<ComboBox Style="{StaticResource MaterialComboBoxStyle}"
-										  SelectedIndex="0"
-										  x:Name="Material_SelectionMode">
-									<ComboBox.Items>
-										<x:String>Single</x:String>
-										<x:String>Multiple</x:String>
-									</ComboBox.Items>
-								</ComboBox>
+					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarView"
+									  smtx:XamlDisplayExtensions.Header="CalendarView"
+									  Style="{StaticResource XamlDisplayBelowStyle}">
+						<StackPanel Spacing="20">
+							<TextBlock Text="Selection Mode:"
+									   Style="{StaticResource MaterialBody1}" />
+							<ComboBox Style="{StaticResource MaterialComboBoxStyle}"
+									  x:Name="Material_SelectionMode">
+								<ComboBox.Items>
+									<ComboBoxItem IsSelected="True">Single</ComboBoxItem>
+									<ComboBoxItem>Multiple</ComboBoxItem>
+								</ComboBox.Items>
+							</ComboBox>
 
-								<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Material_SelectionMode}"
-											  x:Name="Material_CalendarView"
-											  AutomationProperties.AutomationId="Material_CalendarView"
-											  Style="{StaticResource MaterialCalendarViewStyle}" />
-							</StackPanel>
-						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarDatePicker"
-										  smtx:XamlDisplayExtensions.Header="CalendarDatePicker">
-							<CalendarDatePicker Header="Date"
-												x:Name="Material_CalendarDatePicker"
-												AutomationProperties.AutomationId="Material_CalendarDatePicker"
-												Style="{StaticResource MaterialCalendarDatePickerStyle}" />
-						</smtx:XamlDisplay>
-					</StackPanel>
+							<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Material_SelectionMode}"
+										  x:Name="Material_CalendarView"
+										  AutomationProperties.AutomationId="Material_CalendarView"
+										  Style="{StaticResource MaterialCalendarViewStyle}" />
+						</StackPanel>
+					</smtx:XamlDisplay>
 				</DataTemplate>
 			</local:SamplePageLayout.MaterialTemplate>
 			<local:SamplePageLayout.CupertinoTemplate>
 				<DataTemplate>
-					<StackPanel Spacing="20">
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarView"
-										  smtx:XamlDisplayExtensions.Header="CalendarView"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<StackPanel Spacing="20">
-								<TextBlock Text="Selection Mode:"
-										   Style="{StaticResource CupertinoBody}" />
-								<ComboBox Style="{StaticResource CupertinoComboBoxStyle}"
-										  SelectedIndex="0"
-										  x:Name="Cupertino_SelectionMode">
-									<ComboBox.Items>
-										<x:String>Single</x:String>
-										<x:String>Multiple</x:String>
-									</ComboBox.Items>
-								</ComboBox>
+					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarView"
+									  smtx:XamlDisplayExtensions.Header="CalendarView"
+									  Style="{StaticResource XamlDisplayBelowStyle}">
+						<StackPanel Spacing="20">
+							<TextBlock Text="Selection Mode:"
+									   Style="{StaticResource CupertinoBody}" />
+							<ComboBox Style="{StaticResource CupertinoComboBoxStyle}"
+									  x:Name="Cupertino_SelectionMode">
+								<ComboBox.Items>
+									<ComboBoxItem IsSelected="True">Single</ComboBoxItem>
+									<ComboBoxItem>Multiple</ComboBoxItem>
+								</ComboBox.Items>
+							</ComboBox>
 
-								<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Cupertino_SelectionMode}"
-											  x:Name="Cupertino_CalendarView"
-											  AutomationProperties.AutomationId="Cupertino_CalendarView"
-											  Style="{StaticResource CupertinoCalendarViewStyle}" />
-							</StackPanel>
-						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarDatePicker"
-										  smtx:XamlDisplayExtensions.Header="CalendarDatePicker">
-							<CalendarDatePicker Header="Date"
-												x:Name="Cupertino_CalendarDatePicker"
-												AutomationProperties.AutomationId="Cupertino_CalendarDatePicker"
-												Style="{StaticResource CupertinoCalendarDatePickerStyle}" />
-						</smtx:XamlDisplay>
-					</StackPanel>
+							<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Cupertino_SelectionMode}"
+										  x:Name="Cupertino_CalendarView"
+										  AutomationProperties.AutomationId="Cupertino_CalendarView"
+										  Style="{StaticResource CupertinoCalendarViewStyle}" />
+						</StackPanel>
+					</smtx:XamlDisplay>
 				</DataTemplate>
 			</local:SamplePageLayout.CupertinoTemplate>
 			<local:SamplePageLayout.FluentTemplate>
 				<DataTemplate>
-					<StackPanel Spacing="20">
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarView"
-										  smtx:XamlDisplayExtensions.Header="CalendarView"
-										  Style="{StaticResource XamlDisplayBelowStyle}">
-							<StackPanel Spacing="20">
-								<TextBlock Text="Selection Mode:"
-										   Style="{StaticResource BodyTextBlockStyle}" />
-								<ComboBox SelectedIndex="0"
-										  x:Name="Fluent_SelectionMode">
-									<ComboBox.Items>
-										<x:String>Single</x:String>
-										<x:String>Multiple</x:String>
-									</ComboBox.Items>
-								</ComboBox>
+					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarView"
+									  smtx:XamlDisplayExtensions.Header="CalendarView"
+									  Style="{StaticResource XamlDisplayBelowStyle}">
+						<StackPanel Spacing="20">
+							<TextBlock Text="Selection Mode:"
+									   Style="{StaticResource BodyTextBlockStyle}" />
+							<ComboBox x:Name="Fluent_SelectionMode">
+								<ComboBox.Items>
+									<ComboBoxItem IsSelected="True">Single</ComboBoxItem>
+									<ComboBoxItem>Multiple</ComboBoxItem>
+								</ComboBox.Items>
+							</ComboBox>
 
-								<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Fluent_SelectionMode}"
-											  x:Name="Fluent_CalendarView"
-											  AutomationProperties.AutomationId="Fluent_CalendarView" />
-							</StackPanel>
-						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarDatePicker"
-										  smtx:XamlDisplayExtensions.Header="CalendarDatePicker">
-							<CalendarDatePicker Header="Date"
-												x:Name="Fluent_CalendarDatePicker"
-												AutomationProperties.AutomationId="Fluent_CalendarDatePicker" />
-						</smtx:XamlDisplay>
-					</StackPanel>
+							<CalendarView SelectionMode="{Binding SelectedItem, ElementName=Fluent_SelectionMode}"
+										  x:Name="Fluent_CalendarView"
+										  AutomationProperties.AutomationId="Fluent_CalendarView" />
+						</StackPanel>
+					</smtx:XamlDisplay>
 				</DataTemplate>
 			</local:SamplePageLayout.FluentTemplate>
 		</local:SamplePageLayout>

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -105,14 +105,14 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
-		<PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.774" />
+		<PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.778" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="1.0.5-dev.13" />
-		<PackageReference Include="Uno.Material" Version="1.0.0-dev.774" />
+		<PackageReference Include="Uno.Material" Version="1.0.0-dev.778" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
-		<PackageReference Include="Uno.UI.Lottie" Version="3.8.0-dev.439" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="3.8.0-dev.439" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.439" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Lottie" Version="3.8.0-dev.461" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="3.8.0-dev.461" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.461" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0-dev.45" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0-dev.45" />
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5">

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -212,10 +212,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -224,12 +224,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.439" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.461" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.Essentials">

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -103,10 +103,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.0.0-dev.774</Version>
+      <Version>1.0.0-dev.778</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -115,12 +115,12 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>3.8.0-dev.439</Version>
+      <Version>3.8.0-dev.461</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.439" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.461" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6211

## PR Type

What kind of change does this PR introduce?

- Bugfix
 
## What is the current behavior?
DatePicker was on the same page as the CalendarView, causing an overlap of calendar views
Initial selected state of Selection Mode ComboBox appears blank

## What is the new behavior?

CalendarDatePicker and CalendarView have their own sample pages now
Initial selected state of Selection Mode ComboBox is Single


![image](https://user-images.githubusercontent.com/4793020/121369122-9664a900-c909-11eb-96f6-41fafa576224.png)

![image](https://user-images.githubusercontent.com/4793020/121369194-a2e90180-c909-11eb-9f2c-dce58594c14b.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)