### PR TITLE
fix(InfoBar): Add InfoBar Samples

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -254,6 +254,9 @@
     <Compile Include="Views\SamplePages\IconSamplePage.xaml.cs">
       <DependentUpon>IconSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\InfoBarSamplePage.xaml.cs">
+      <DependentUpon>InfoBarSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\ListViewSamplePage.xaml.cs">
       <DependentUpon>ListViewSamplePage.xaml</DependentUpon>
     </Compile>
@@ -499,6 +502,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\SamplePages\IconSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\InfoBarSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBarSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBarSamplePage.xaml
@@ -1,0 +1,104 @@
+﻿<Page x:Class="Uno.Gallery.Views.SamplePages.InfoBarSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Gallery.Views.SamplePages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:sample="using:Uno.Gallery"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  xmlns:winui="using:Microsoft.UI.Xaml.Controls"
+	  mc:Ignorable="d">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<sample:SamplePageLayout>
+			<sample:SamplePageLayout.MaterialTemplate>
+				<DataTemplate>
+					<StackPanel Spacing="20"
+								Margin="0,20,0,0">
+						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Error_SingleButton"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<winui:InfoBar x:Name="firstInfo"
+										   Title="Title"
+										   IsOpen="True"
+										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										   IsIconVisible="True"
+										   Severity="Error"
+										   Style="{StaticResource MaterialInfoBarStyle}">
+								<winui:InfoBar.Content>
+									<Button Style="{StaticResource MaterialTextButtonStyle}"
+											Content="DISMISS" />
+								</winui:InfoBar.Content>
+								<winui:InfoBar.IconSource>
+									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+															Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</winui:InfoBar.IconSource>
+							</winui:InfoBar>
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Warning_DoubleButton"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<winui:InfoBar x:Name="secondInfo"
+										   Title="Title"
+										   IsOpen="True"
+										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										   IsIconVisible="True"
+										   Severity="Warning"
+										   Style="{StaticResource MaterialInfoBarStyle}">
+								<winui:InfoBar.Content>
+									<StackPanel Orientation="Horizontal"
+												Spacing="8">
+										<Button Style="{StaticResource MaterialTextButtonStyle}"
+												Content="DISMISS" />
+										<Button Style="{StaticResource MaterialTextButtonStyle}"
+												Content="ACTION" />
+									</StackPanel>
+								</winui:InfoBar.Content>
+								<winui:InfoBar.IconSource>
+									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+															Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</winui:InfoBar.IconSource>
+							</winui:InfoBar>
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Success_SingleButton"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<winui:InfoBar x:Name="thirdInfo"
+										   Title="Title"
+										   IsOpen="True"
+										   Message="Essential app message for your users to be informed of, acknowledge, or take action on."
+										   Severity="Success"
+										   IsIconVisible="False"
+										   Style="{StaticResource MaterialInfoBarStyle}">
+								<winui:InfoBar.Content>
+									<Button Style="{StaticResource MaterialTextButtonStyle}"
+											Content="DISMISS" />
+								</winui:InfoBar.Content>
+							</winui:InfoBar>
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="Material_InfoBarSamplePage_Information_SingleButton"
+										  Style="{StaticResource XamlDisplayBelowStyle}">
+							<winui:InfoBar x:Name="fourthInfo"
+										   Title="Title"
+										   IsOpen="True"
+										   Message="Single line essential app message."
+										   Severity="Informational"
+										   MinHeight="54"
+										   IsIconVisible="True"
+										   Style="{StaticResource MaterialInfoBarStyle}">
+								<winui:InfoBar.ActionButton>
+									<Button Style="{StaticResource MaterialTextButtonStyle}"
+											Content="DISMISS" />
+								</winui:InfoBar.ActionButton>
+								<winui:InfoBar.IconSource>
+									<winui:BitmapIconSource UriSource="/Assets/MaterialIcon_Medium.png"
+															Foreground="{StaticResource MaterialPrimaryBrush}" />
+								</winui:InfoBar.IconSource>
+							</winui:InfoBar>
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</sample:SamplePageLayout.MaterialTemplate>
+		</sample:SamplePageLayout>
+	</Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBarSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBarSamplePage.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+
+namespace Uno.Gallery.Views.SamplePages
+{
+	[SamplePage(SampleCategory.Components, "InfoBar", Description = "This control is an inline notification for essential app-wide messages.", DocumentationLink = "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.infobar?view=winui-2.5")]
+	public sealed partial class InfoBarSamplePage : Page
+	{
+		public InfoBarSamplePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #293 

## PR Type

What kind of change does this PR introduce?

- Missing sample

## What is the current behavior?

No InfoBar samples are available in Uno.Gallery


## What is the new behavior?

InfoBar samples added in Uno.Gallery


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)
