### PR TITLE
fix(ToggleSwitch): Material styles not displaying correctly on WASM

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -108,10 +108,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -27,8 +27,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino" Version="1.1.0-dev.57" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Cupertino" Version="1.1.0-dev.64" />
+		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -40,10 +40,10 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.0-dev.7" />
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/ToggleSwitch.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/ToggleSwitch.xaml
@@ -6,29 +6,6 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					mc:Ignorable="d android wasm">
 
-	<!--Workaround for #192132 wasm: prefix issue-->
-	<wasm:Style x:Key="MaterialToggleSwitchStyle"
-				TargetType="ToggleSwitch"
-				BasedOn="{StaticResource DefaultMaterialToggleSwitchStyle}">
-	</wasm:Style>
-
-	<wasm:Style x:Key="MaterialSecondaryToggleSwitchStyle"
-				TargetType="ToggleSwitch"
-				BasedOn="{StaticResource DefaultMaterialToggleSwitchStyle}">
-
-		<Setter Property="Foreground"
-				Value="{StaticResource MaterialSecondaryVariantDarkBrush}" />
-		<Setter Property="Background"
-				Value="{StaticResource MaterialSecondaryVariantLightBrush}" />
-	</wasm:Style>
-
-	<wasm:Style x:Key="CupertinoToggleSwitchStyle"
-				TargetType="ToggleSwitch"
-				BasedOn="{StaticResource DefaultCupertinoToggleSwitchStyle}">
-		<Setter Property="CornerRadius"
-		        Value="14" />
-	</wasm:Style>
-
 	<!-- Native ToggleSwitch colors -->
 	<SolidColorBrush x:Key="NativeOffThumbTint"
 					 Color="#FFECECEC" />

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -111,9 +111,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
-		<PackageReference Include="Uno.Cupertino" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Cupertino" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.0.0-dev.22" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
 		<PackageReference Include="Uno.Toolkit.UI.Material" Version="0.1.0-dev.169" />

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -214,10 +214,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -103,10 +103,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>


### PR DESCRIPTION
GitHub Issue (If applicable): #314

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Material ToggleSwitch styles are not displaying correctly on WASM


## What is the new behavior?

Material ToggleSwitch styles are now displaying correctly on WASM


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)
