### PR TITLE
chore(Android): Remove workarounds not needed anymore

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -14,8 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
-    <!-- AndroidUseAapt2 is disabled until https://github.com/unoplatform/uno/issues/1382 is resolved -->
-    <AndroidUseAapt2>false</AndroidUseAapt2>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
@@ -258,6 +257,4 @@
   </ItemGroup>
   <Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <!-- This will force the generation of the APK when not building inside visual studio -->
-  <Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''" />
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Android project file changes

## Description

- Enable again AndroidUseAapt2 as https://github.com/unoplatform/uno/issues/1382 is now resolved
- Remove the target that will force the generation of the APK as it's not needed anymore and as it causes issues to deploy on Android with latest VS 2022 Prev 17.1.0 Preview 1.0 and 1.1


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [X] Tested on Android.
- [ ] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
