### PR TITLE
fix: Update Button FlyoutPresenterStyle in the sample to match latest changes in Uno.Material 

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FlyoutSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FlyoutSamplePage.xaml
@@ -22,7 +22,7 @@
 							<Button Content="Flyout"
 									Style="{StaticResource MaterialContainedButtonStyle}">
 								<Button.Flyout>
-									<Flyout FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
+									<Flyout FlyoutPresenterStyle="{StaticResource MaterialContentFlyoutPresenterStyle}">
 										<TextBlock
 												   Style="{StaticResource MaterialBody2}" >
 <TextBlock.Text>


### PR DESCRIPTION
GitHub Issue (If applicable): #https://github.com/unoplatform/uno/issues/7566

## PR Type

- Bugfix

## What is the current behavior?

For the Material Button 'Flyout' sample, the text is overlapping the whole screen and not styled like it should

## What is the new behavior?

Update Button FlyoutPresenterStyle in the sample to match the latest style name changes in Uno.Material 
(Related to this commit and breaking change in Uno.Material : https://github.com/unoplatform/Uno.Themes/commit/6a0f105a5b9d120c00a09776beb2290826e1a042)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)
