### PR TITLE
fix: CalendarView xaml display style

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
@@ -14,7 +14,7 @@
 				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Material_CalendarView"
 									  smtx:XamlDisplayExtensions.Header="CalendarView"
-									  Style="{StaticResource XamlDisplayBelowStyle}">
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 							<TextBlock Text="Selection Mode:"
 									   Style="{StaticResource MaterialBody1}" />
@@ -38,7 +38,7 @@
 				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Cupertino_CalendarView"
 									  smtx:XamlDisplayExtensions.Header="CalendarView"
-									  Style="{StaticResource XamlDisplayBelowStyle}">
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 							<TextBlock Text="Selection Mode:"
 									   Style="{StaticResource CupertinoBody}" />
@@ -62,7 +62,7 @@
 				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="CalendarViewSamplePage_Fluent_CalendarView"
 									  smtx:XamlDisplayExtensions.Header="CalendarView"
-									  Style="{StaticResource XamlDisplayBelowStyle}">
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 							<TextBlock Text="Selection Mode:"
 									   Style="{StaticResource BodyTextBlockStyle}" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#7023

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: styling

## What is the new behavior?

Minor visual change

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

## Other information
Align XamlDisplay style with other controls: "See Xaml" -> "<>"