### PR TITLE
 Bring back mobile/not_mobile XAML namespaces

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -255,6 +255,10 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
+  <ItemGroup>
+	  <IncludeXamlNamespaces Include="mobile" />
+	  <ExcludeXamlNamespaces Include="not_mobile" />
+  </ItemGroup>
   <Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -72,4 +72,8 @@
 	  <None Remove="Assets\Fonts\uno-fluentui-assets.ttf" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<IncludeXamlNamespaces Include="not_mobile" />
+		<ExcludeXamlNamespaces Include="mobile" />
+	</ItemGroup>
 </Project>

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -175,6 +175,10 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
+		<IncludeXamlNamespaces Include="not_mobile" />
+		<ExcludeXamlNamespaces Include="mobile" />
+	</ItemGroup>
+  <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
     <ApplicationDefinition Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -91,6 +91,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<IncludeXamlNamespaces Include="not_mobile" />
+		<ExcludeXamlNamespaces Include="mobile" />
+	</ItemGroup>
+	
+	<ItemGroup>
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -12,6 +12,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <ResourcesDirectory>..\Uno.Gallery.Shared\Strings</ResourcesDirectory>
+    <ProvisioningType>manual</ProvisioningType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -252,6 +253,10 @@
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
   </ItemGroup>
+  <ItemGroup>
+		<IncludeXamlNamespaces Include="mobile" />
+		<ExcludeXamlNamespaces Include="not_mobile" />
+	</ItemGroup>
   <Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -216,4 +216,8 @@
     </ItemGroup>
     <Copy SourceFiles="@(_packages)" DestinationFolder="$(PackageOutputPath)\" />
   </Target>
+  <ItemGroup>
+		<IncludeXamlNamespaces Include="not_mobile" />
+		<ExcludeXamlNamespaces Include="mobile" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

Bring back mobile/not_mobile XAML namespaces so we can exclude/include certain samples based on platform
