### PR TITLE
fix: TabBar Sample App Page crash for UWP and remove MaterialToolkitColors following breaking change

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -107,10 +107,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -119,21 +119,21 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.494" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.515" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
@@ -146,7 +146,7 @@
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.6.1</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.494" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.515" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
   </ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -32,8 +32,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino" Version="1.4.0-dev.17" />
-		<PackageReference Include="Uno.Material" Version="1.4.0-dev.17" />
+		<PackageReference Include="Uno.Cupertino" Version="1.4.0-dev.30" />
+		<PackageReference Include="Uno.Material" Version="1.4.0-dev.30" />
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
@@ -51,13 +51,13 @@
 		</PackageReference>
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.3.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="1.3.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.3.0" />		
-		<PackageReference Include="Uno.UI.Lottie" Version="4.2.0-dev.494" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.2.0-dev.494" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="1.4.0-dev.4" />
+		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="1.4.0-dev.4" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.4.0-dev.4" />		
+		<PackageReference Include="Uno.UI.Lottie" Version="4.2.0-dev.515" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.2.0-dev.515" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.29" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.494" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.515" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.UWP/App.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/App.xaml
@@ -26,7 +26,6 @@
 				<CupertinoResources xmlns="using:Uno.Cupertino" />
 
 				<!--  Load Material Toolkit resources  -->
-				<MaterialToolkitColors xmlns="using:Uno.Toolkit.UI.Material" />
 				<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />
 
                 <!-- Load Cupertino Toolkit resources -->

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -40,10 +40,10 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -52,16 +52,16 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -116,16 +116,16 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
-		<PackageReference Include="Uno.Cupertino" Version="1.4.0-dev.17" />
+		<PackageReference Include="Uno.Cupertino" Version="1.4.0-dev.30" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0-dev.1" />
-		<PackageReference Include="Uno.Material" Version="1.4.0-dev.17" />
+		<PackageReference Include="Uno.Material" Version="1.4.0-dev.30" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.0.59" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.0.59" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.3.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="1.3.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.3.0" />
-		<PackageReference Include="Uno.UI.Lottie" Version="4.2.0-dev.494" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="4.2.0-dev.494" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="1.4.0-dev.4" />
+		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="1.4.0-dev.4" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.4.0-dev.4" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.2.0-dev.515" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="4.2.0-dev.515" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.29" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="4.0.0-dev.101" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="4.0.0-dev.101" />
@@ -137,7 +137,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.494" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.515" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -214,10 +214,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -226,21 +226,21 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.494" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.515" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.Essentials">
@@ -249,7 +249,7 @@
     <PackageReference Include="Xamarin.TestCloud.Agent">
       <Version>0.22.2</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.494" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.515" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
   </ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -103,10 +103,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>1.4.0-dev.17</Version>
+      <Version>1.4.0-dev.30</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.0.59</Version>
@@ -115,24 +115,24 @@
       <Version>1.0.59</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>1.3.0</Version>
+      <Version>1.4.0-dev.4</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.2.0-dev.494</Version>
+      <Version>4.2.0-dev.515</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.494" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.515" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.494" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.515" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.0-dev.4" />
   </ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable):  related issue https://github.com/unoplatform/uno.toolkit.ui/issues/205

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

TabBar Sample App Page crashes for UWP


## What is the new behavior?

No more TabBar Sample App Page crash for UWP

Fix TabBar Sample App Page crash for UWP and remove MaterialToolkitColors following breaking change with latest Uno.Toolkit.UI breaking change


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

