### PR TITLE
documentation corrections - MacOS -> macOS

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -194,7 +194,7 @@ All rights reserved.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 UNO Platform Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -194,7 +194,7 @@ All rights reserved.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 UNO Platform Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Available on:
 - Android
 - Windows
 - WebAssembly
-- MacOS
+- macOS
 - Linux (experimental)
 
 ![Screenshot](./images/Screenshot1.png)


### PR DESCRIPTION
Documentaion

- in Readme, corrected naming from MacOS to macOS