### PR TITLE
fix: color listview sample not selectable

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ListViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ListViewSamplePage.xaml
@@ -82,6 +82,7 @@ public List<Record> Data { get; } = new List<Record>
 								<!-- Selection-->
 								<ListView x:Name="ColorPicker"
 										  IsItemClickEnabled="True"
+										  SelectionMode="Single"
 										  SelectedIndex="0"
 										  Margin="0,16,0,0">
 


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno#8982

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
ListView sample's color listview is not selectable...

## What is the new behavior?
is now.


## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [ ] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

## Other information
Appears that the default style has since changed, `SelectionMode` was no longer defaulted to `Single`.