### PR TITLE
fix: Material ElevatedButtonStyle samples not correctly visible in Dark mode in Gallery

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
@@ -21,7 +21,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialElevated"
 										  smtx:XamlDisplayExtensions.Header="Elevated Button"
 										  smtx:XamlDisplayExtensions.Description="Elevated buttons are essentially filled tonal buttons with a shadow. To prevent shadow creep, only use them when absolutely necessary, such as when the button requires visual separation from a patterned background."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel Spacing="20">
 
 								<Button Content="ELEVATED" Style="{StaticResource ElevatedButtonStyle}" />
@@ -41,7 +42,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialFilled"
 										  smtx:XamlDisplayExtensions.Header="Filled Buttons"
 										  smtx:XamlDisplayExtensions.Description="Filled buttons have the most visual impact after the FAB, and should be used for important, final actions that complete a flow, like Save, Join now, or Confirm."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel Spacing="20">
 
 								<Button Content="FILLED" Style="{StaticResource FilledButtonStyle}" />
@@ -61,7 +63,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialFilledTonal"
 										  smtx:XamlDisplayExtensions.Header="Filled Tonal Buttons"
 										  smtx:XamlDisplayExtensions.Description="A filled tonal button is an alternative middle ground between filled and outlined buttons. They're useful in contexts where a lower-priority button requires slightly more emphasis than an outline would give, such as 'Next' in an onboarding flow. Tonal buttons use the secondary color mapping."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel Spacing="20">
 
 								<Button Content="FILLED TONAL" Style="{StaticResource FilledTonalButtonStyle}" />
@@ -81,7 +84,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialOutlined"
 										  smtx:XamlDisplayExtensions.Header="Outlined Buttons"
 										  smtx:XamlDisplayExtensions.Description="Outlined buttons are medium-emphasis buttons. They contain actions that are important, but aren't the primary action in an app. Outlined buttons pair well with filled buttons to indicate an alternative, secondary action."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel Spacing="20">
 
 								<Button Content="OUTLINED" Style="{StaticResource OutlinedButtonStyle}" />
@@ -101,7 +105,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialText"
 										  smtx:XamlDisplayExtensions.Header="Text Buttons"
 										  smtx:XamlDisplayExtensions.Description="Text buttons are used for the lowest priority actions, especially when presenting multiple options. Text buttons can be placed on a variety of backgrounds. Until the button is interacted with, its container isn't visible."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel>
 
 								<Button Content="TEXT" Style="{StaticResource TextButtonStyle}" />
@@ -121,7 +126,8 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialIcon"
 										  smtx:XamlDisplayExtensions.Header="Icon Buttons"
 										  smtx:XamlDisplayExtensions.Description="Use icon buttons to display actions in a compact layout. Icon buttons can represent opening actions such as opening an overflow menu or search, or represent binary actions that can be toggled on and off, such as favorite or bookmark."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+                                          Background="{StaticResource SampleSecondBackgroundBrush}">
 							<StackPanel Spacing="20">
 
 								<Button Style="{StaticResource IconButtonStyle}">

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
@@ -81,7 +81,7 @@
 								<RowDefinition Height="Auto" />
 							</Grid.RowDefinitions>
 
-							<Grid>
+                            <Grid Background="{TemplateBinding Background}">
 								<Grid.ColumnDefinitions>
 									<ColumnDefinition Width="*" />
 									<ColumnDefinition Width="Auto"


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno/issues/8991

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix Material ElevatedButtonStyle samples not correctly visible in Dark mode in Gallery

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

