### PR TITLE
Fix multiple visual issues for Gallery

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
+++ b/Uno.Gallery/Uno.Gallery.Droid/Uno.Gallery.Droid.csproj
@@ -87,10 +87,10 @@
       <Version>7.0.7</Version>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.1.0</Version>
@@ -99,21 +99,21 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
@@ -126,7 +126,7 @@
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.6.1</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
   </ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -40,20 +40,20 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="4.3.6" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+		<PackageReference Include="Uno.UI" Version="4.3.8" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.Cupertino" Version="2.0.0" />
+		<PackageReference Include="Uno.Cupertino" Version="2.1.0" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.0.1" />
-		<PackageReference Include="Uno.Material" Version="2.0.0" />
+		<PackageReference Include="Uno.Material" Version="2.1.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.1.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.1.0" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.0.0" />
-		<PackageReference Include="Uno.UI.Lottie" Version="4.3.6" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.1.0" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.3.8" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.Properties.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.Properties.cs
@@ -42,13 +42,13 @@ namespace Uno.Gallery
 
 		public static DependencyProperty DocumentationLinkProperty { get; } = DependencyProperty.Register(
 			nameof(DocumentationLink),
-			typeof(string),
+			typeof(Uri),
 			typeof(SamplePageLayout),
 			new PropertyMetadata(default));
 
-		public string DocumentationLink
+		public Uri DocumentationLink
 		{
-			get => (string)GetValue(DocumentationLinkProperty);
+			get => (Uri)GetValue(DocumentationLinkProperty);
 			set => SetValue(DocumentationLinkProperty, value);
 		}
 

--- a/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.cs
@@ -86,7 +86,7 @@ namespace Uno.Gallery
 					IsFooterVisible = true;
 					IsShareVisible = true;
 #else
-					IsFooterVisible = !string.IsNullOrWhiteSpace(sample.DocumentationLink);
+					IsFooterVisible = sample.DocumentationLink != null;
 					IsShareVisible = false;
 #endif
 				}

--- a/Uno.Gallery/Uno.Gallery.Shared/Entities/Sample.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Entities/Sample.cs
@@ -17,7 +17,10 @@ namespace Uno.Gallery
 			Category = attribute.Category;
 			Title = attribute.Title;
 			Description = attribute.Description;
-			DocumentationLink = attribute.DocumentationLink;
+			if (attribute.DocumentationLink != null)
+			{
+				DocumentationLink = new Uri(attribute.DocumentationLink);
+			}
 			Data = CreateData(attribute.DataType);
 			Source = attribute.Source;
 			SortOrder = attribute.SortOrder;
@@ -46,7 +49,7 @@ namespace Uno.Gallery
 
 		public string Description { get; }
 
-		public string DocumentationLink { get; }
+		public Uri DocumentationLink { get; }
 
 		public object Data { get; }
 

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -32,20 +32,20 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino" Version="2.0.0" />
-		<PackageReference Include="Uno.Material" Version="2.0.0" />
+		<PackageReference Include="Uno.Cupertino" Version="2.1.0" />
+		<PackageReference Include="Uno.Material" Version="2.1.0" />
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.1.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.1.0" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.0.0" />		
-		<PackageReference Include="Uno.UI.Lottie" Version="4.3.6" />
-		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.3.6" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.1.0" />		
+		<PackageReference Include="Uno.UI.Lottie" Version="4.3.8" />
+		<PackageReference Include="Uno.UI.Skia.Gtk" Version="4.3.8" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -20,10 +20,10 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.1.0-dev.4" />
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.1.0</Version>
@@ -32,16 +32,16 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Colors.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Colors.xaml
@@ -21,7 +21,10 @@
 	<SolidColorBrush x:Key="SampleSecondBackgroundBrush"
 					 Color="{ThemeResource OnSurfaceColor}"
 					 Opacity="0.05" />
-	<SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
+    <SolidColorBrush x:Key="SampleThirdBackgroundBrush"
+                     Color="{ThemeResource OnSurfaceColor}"
+                     Opacity="0.02" />
+    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
 					 Color="{ThemeResource BackgroundColor}" />
 
 	<Color x:Key="UnoBlueColor">#FF229DFC</Color>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/GeneralPages/OverviewPage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/GeneralPages/OverviewPage.xaml
@@ -116,19 +116,20 @@
 						</StackPanel>
 					</local:OverviewSampleView>
 
-					<!-- todo: ToggleSwitch (not supported yet for m3) -->
-					<todo:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
+					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
 						<StackPanel Spacing="8">
 
 							<ToggleSwitch Header="ToggleSwitch"
 										  IsOn="True"
-										  Style="{StaticResource MaterialToggleSwitchStyle}" />
+                                          MinWidth="200"
+										  Style="{StaticResource ToggleSwitchStyle}" />
 							<ToggleSwitch Header="Disabled"
 										  IsEnabled="False"
-										  Style="{StaticResource MaterialToggleSwitchStyle}" />
+                                          MinWidth="200"
+										  Style="{StaticResource ToggleSwitchStyle}" />
 
 						</StackPanel>
-					</todo:OverviewSampleView>
+					</local:OverviewSampleView>
 
 				</StackPanel>
 			</DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
@@ -21,8 +21,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialElevated"
 										  smtx:XamlDisplayExtensions.Header="Elevated Button"
 										  smtx:XamlDisplayExtensions.Description="Elevated buttons are essentially filled tonal buttons with a shadow. To prevent shadow creep, only use them when absolutely necessary, such as when the button requires visual separation from a patterned background."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
 								<Button Content="ELEVATED" Style="{StaticResource ElevatedButtonStyle}" />
@@ -42,8 +41,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialFilled"
 										  smtx:XamlDisplayExtensions.Header="Filled Buttons"
 										  smtx:XamlDisplayExtensions.Description="Filled buttons have the most visual impact after the FAB, and should be used for important, final actions that complete a flow, like Save, Join now, or Confirm."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
 								<Button Content="FILLED" Style="{StaticResource FilledButtonStyle}" />
@@ -63,8 +61,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialFilledTonal"
 										  smtx:XamlDisplayExtensions.Header="Filled Tonal Buttons"
 										  smtx:XamlDisplayExtensions.Description="A filled tonal button is an alternative middle ground between filled and outlined buttons. They're useful in contexts where a lower-priority button requires slightly more emphasis than an outline would give, such as 'Next' in an onboarding flow. Tonal buttons use the secondary color mapping."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
 								<Button Content="FILLED TONAL" Style="{StaticResource FilledTonalButtonStyle}" />
@@ -84,8 +81,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialOutlined"
 										  smtx:XamlDisplayExtensions.Header="Outlined Buttons"
 										  smtx:XamlDisplayExtensions.Description="Outlined buttons are medium-emphasis buttons. They contain actions that are important, but aren't the primary action in an app. Outlined buttons pair well with filled buttons to indicate an alternative, secondary action."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
 								<Button Content="OUTLINED" Style="{StaticResource OutlinedButtonStyle}" />
@@ -105,8 +101,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialText"
 										  smtx:XamlDisplayExtensions.Header="Text Buttons"
 										  smtx:XamlDisplayExtensions.Description="Text buttons are used for the lowest priority actions, especially when presenting multiple options. Text buttons can be placed on a variety of backgrounds. Until the button is interacted with, its container isn't visible."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel>
 
 								<Button Content="TEXT" Style="{StaticResource TextButtonStyle}" />
@@ -126,8 +121,7 @@
 						<smtx:XamlDisplay UniqueKey="ButtonSamplePage_MaterialIcon"
 										  smtx:XamlDisplayExtensions.Header="Icon Buttons"
 										  smtx:XamlDisplayExtensions.Description="Use icon buttons to display actions in a compact layout. Icon buttons can represent opening actions such as opening an overflow menu or search, or represent binary actions that can be toggled on and off, such as favorite or bookmark."
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
-                                          Background="{StaticResource SampleSecondBackgroundBrush}">
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
 								<Button Style="{StaticResource IconButtonStyle}">

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ListViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ListViewSamplePage.xaml
@@ -73,8 +73,8 @@ public List<Record> Data { get; } = new List<Record>
 							<StackPanel>
 
 								<!-- Chosen Color -->
-								<TextBlock Foreground="{Binding SelectedItem.Foreground, ElementName=ColorPicker}"
-										   Height="20">
+                                <TextBlock Foreground="{Binding SelectedItem.Foreground, ElementName=ColorPicker, TargetNullValue={StaticResource OnSurfaceBrush}, FallbackValue={StaticResource OnSurfaceBrush}}"
+                                           Style="{StaticResource BodyLarge}">
 									<Run Text="Foreground color:" />
 									<Run Text="{Binding SelectedItem.Content, ElementName=ColorPicker}" />
 								</TextBlock>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TabBarSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TabBarSamplePage.xaml
@@ -106,6 +106,7 @@
 						</TextBlock>
 					</StackPanel>
 					<Button Content="Reset all counters"
+                            Command="{Binding Data.ResetAllCounterCommand}"
 							HorizontalAlignment="Center"
 							Style="{StaticResource OutlinedButtonStyle}" />
 

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/SamplePageLayout.xaml
@@ -81,7 +81,7 @@
 
 						<ScrollViewer x:Name="PART_ScrollViewer"
 									  Grid.Row="1">
-							<Grid Margin="0,0,0,24">
+							<Grid Padding="0,0,0,24">
 								<Grid.RowDefinitions>
 									<RowDefinition Height="*" />
 									<RowDefinition Height="Auto" />

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Styles/XamlDisplay.xaml
@@ -23,8 +23,10 @@
 				Value="1" />
 		<Setter Property="Formatter"
 				Value="{x:Null}" />
+        <Setter Property="Background"
+                Value="{StaticResource SampleSecondBackgroundBrush}" />
 
-		<Setter Property="Template">
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="smtx:XamlDisplay">
 					<StackPanel>
@@ -105,7 +107,7 @@
 											  Style="{StaticResource XamlDisplayExpandToggleButtonStyle}" />
 							</Grid>
 
-							<ScrollViewer Background="{StaticResource SampleSecondBackgroundBrush}"
+                            <ScrollViewer Background="{StaticResource SampleThirdBackgroundBrush}"
 										  HorizontalScrollBarVisibility="Auto"
 										  VerticalScrollBarVisibility="Disabled"
 										  win:Visibility="{Binding Path=(smtx:XamlDisplayExtensions.ShowXaml), RelativeSource={RelativeSource TemplatedParent}}"
@@ -168,9 +170,9 @@
 
 	<Style x:Key="DefaultXamlPresenterStyle"
 		   TargetType="smtx:XamlPresenter">
-		<Setter Property="Formatter"
-				Value="{StaticResource NiceFormatter}" />
-		<Setter Property="Template">
+        <Setter Property="Formatter"
+                Value="{StaticResource NiceFormatter}" />
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="smtx:XamlPresenter">
 					<Grid>
@@ -180,6 +182,7 @@
 						</Grid.RowDefinitions>
 
 						<ContentControl Content="{Binding Tag, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                        VerticalContentAlignment="Center"
 										android:Visibility="Collapsed"
 										ios:Visibility="Collapsed" />
 
@@ -193,7 +196,7 @@
 									  ios:Visibility="Collapsed"
 									  Style="{StaticResource XamlDisplayExpandToggleButtonStyle}" />
 
-						<ScrollViewer Background="{StaticResource SampleSecondBackgroundBrush}"
+						<ScrollViewer Background="{StaticResource SampleThirdBackgroundBrush}"
 									  HorizontalScrollBarVisibility="Auto"
 									  VerticalScrollBarVisibility="Disabled"
 									  win:Visibility="{Binding ElementName=RevealButton, Path=IsChecked, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -100,17 +100,17 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
-		<PackageReference Include="Uno.Cupertino" Version="2.0.0" />
+		<PackageReference Include="Uno.Cupertino" Version="2.1.0" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.0.1" />
-		<PackageReference Include="Uno.Material" Version="2.0.0" />
+		<PackageReference Include="Uno.Material" Version="2.1.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="1.1.0" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="1.1.0" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.0.0" />
-		<PackageReference Include="Uno.UI.Lottie" Version="4.3.6" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="4.3.6" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Cupertino" Version="2.1.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="2.1.0" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.3.8" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="4.3.8" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="4.0.0-dev.107" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="4.0.0-dev.107" />
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5">
@@ -121,7 +121,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.iOS/Uno.Gallery.iOS.csproj
@@ -194,10 +194,10 @@
       <Version>7.0.7</Version>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.1.0</Version>
@@ -206,21 +206,21 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0" />
     <PackageReference Include="Xamarin.Essentials">
@@ -229,7 +229,7 @@
     <PackageReference Include="Xamarin.TestCloud.Agent">
       <Version>0.22.2</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
   </ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
+++ b/Uno.Gallery/Uno.Gallery.macOS/Uno.Gallery.macOS.csproj
@@ -103,10 +103,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.ShowMeTheXAML">
       <Version>1.1.0</Version>
@@ -115,24 +115,24 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Cupertino">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI.Lottie">
-      <Version>4.3.6</Version>
+      <Version>4.3.8</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
     <PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): Resolves https://github.com/unoplatform/uno/issues/8840, Resolves https://github.com/unoplatform/uno/issues/8790, Resolves https://github.com/unoplatform/uno/issues/8955, Resolves https://github.com/unoplatform/uno/issues/8989, Resolves https://github.com/unoplatform/uno/issues/8990, Resolves https://github.com/unoplatform/uno/issues/9011

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix multiple visual issues for Gallery:
- [Add back the M3 ToggleSwitch sample for the Overview Page](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/3963d04f9cecc47a3a3bcd93e2ee791d0257b14b)
- [Fix Padding issue for the Overview bottom page](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/280e090c3dc8ac8548e1d756e3d8cb2eed3d0611)
- [Update Uno.UI, Uno.Themes and Uno.Toolkit.UI packages to latest stable](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/37afcbdacab8a30f49d9b0ea517a5942caffd2be) 
- [Fix failed to convert value of type string to type Uri BindingExpression Path='DocumentationLink'](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/e9b6211393ed0ca1ad737efbf5269aabf425f487) 
- [Fix samples not visible enough on Dark Theme](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/9d200fec8d1facba8fd90a4710178a1cd544f7a1)
- [Fix ListView sample foreground color text not visible in light and dark theme](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/273ec4da9ff929c9fde43c63332f8a77f68bdfe5) 
- [Fix 'Reset All counters' button is not resetting the click count for TabBar Material Sample](https://github.com/unoplatform/Uno.Gallery/pull/391/commits/98e94d451584db20b6feb6f7c661954550c265b1) 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)
