### PR TITLE
chore: re-enable toggleSwitch sample in Overview

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/GeneralPages/OverviewPage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/GeneralPages/OverviewPage.xaml
@@ -116,8 +116,7 @@
 						</StackPanel>
 					</local:OverviewSampleView>
 
-					<!-- todo: ToggleSwitch (not supported yet for m3) -->
-					<todo:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
+					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
 						<StackPanel Spacing="8">
 
 							<ToggleSwitch Header="ToggleSwitch"
@@ -128,7 +127,7 @@
 										  Style="{StaticResource MaterialToggleSwitchStyle}" />
 
 						</StackPanel>
-					</todo:OverviewSampleView>
+					</local:OverviewSampleView>
 
 				</StackPanel>
 			</DataTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#9008

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

re-enable toggleSwitch sample in Overview

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)