### PR TITLE
chore: add examples for disabled NavigationBackButton

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/ButtonSamplePage.xaml
@@ -175,8 +175,10 @@
 										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="20">
 
-								<Button Style="{StaticResource NavigationBackButtonNormalStyle}" />
 								<Button Style="{StaticResource NavigationBackButtonSmallStyle}" />
+								<Button Style="{StaticResource NavigationBackButtonNormalStyle}" />
+								<Button IsEnabled="False" Style="{StaticResource NavigationBackButtonSmallStyle}" />
+								<Button IsEnabled="False" Style="{StaticResource NavigationBackButtonNormalStyle}" />
 
 							</StackPanel>
 						</smtx:XamlDisplay>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#9117

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Fluent Button examples for back button are missing their disabled equivalent.

## What is the new behavior?

add examples for disabled NavigationBackButton

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)