### PR TITLE
fix(net6-droid): ITextWatcherInvoker TypeLoadException

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Android/Main.Android.cs
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Android/Main.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Android.App;
@@ -22,6 +23,7 @@ namespace Uno.Gallery.Droid
 	)]
 	public class Application : Windows.UI.Xaml.NativeApplication
 	{
+		[DynamicDependency(DynamicallyAccessedMemberTypes.All, "Android.Text.ITextWatcherInvoker", "Mono.Android")] // xamarin/xamarin-android#7097
 		public Application(IntPtr javaReference, JniHandleOwnership transfer)
 			: base(() => new App(), javaReference, transfer)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#8790

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On net6-droid in release, any DataTemplate/Page using ITextWatcherInvoker under the hood crashes with:
	TypeLoadException: Could not load type '{0}' from assembly '{1}'., Android.Text.ITextWatcherInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

## What is the new behavior?
No more crash

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

## Other information
`<LinkDescription />` does not work for the `Uno.Gallery.Mobile.csproj`, so `[DynamicDependency]` had to be used instead.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->