### PR TITLE
feat: Add File & Folder picker sample

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -202,6 +202,9 @@
     <Compile Include="Views\SamplePages\AcrylicSamplePage.xaml.cs">
       <DependentUpon>AcrylicSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\FileFolderPickerSamplePage.xaml.cs">
+      <DependentUpon>FileFolderPickerSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\RefreshContainerPage.xaml.cs">
       <DependentUpon>RefreshContainerPage.xaml</DependentUpon>
     </Compile>    
@@ -464,6 +467,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\SamplePages\AcrylicSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\FileFolderPickerSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml
@@ -1,0 +1,199 @@
+﻿<Page x:Class="Uno.Gallery.Views.Samples.FileFolderPickerSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Gallery"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  mc:Ignorable="d">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickFile"
+										  smtx:XamlDisplayExtensions.Header="Pick a single file">
+							<Button Content="Open file" Click="PickFileButton_Click"/>
+							<!--
+private async void PickFileButton_Click(object sender, RoutedEventArgs e)
+{
+	var picker = new FileOpenPicker();
+	picker.FileTypeFilter.Add("*");
+	var storageFile = await picker.PickSingleFileAsync();
+
+	if (storageFile != null)
+	{
+		// Successfully picked file.
+	}
+	else
+	{
+		// Did not pick any file.
+	}
+}
+-->
+						</smtx:XamlDisplay>
+						
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickMultipleFiles"
+										  smtx:XamlDisplayExtensions.Header="Pick multiple files">
+							<Button Content="Open files" Click="PickMultipleFilesButton_Click"/>
+							<!--
+private async void PickMultipleFilesButton_Click(object sender, RoutedEventArgs e)
+{
+	var picker = new FileOpenPicker();
+	picker.FileTypeFilter.Add("*");
+	var storageFiles = await picker.PickMultipleFilesAsync();
+
+	if (storageFiles != null && storageFiles.Any())
+	{
+		foreach (var file in storageFiles)
+		{
+			// Do something with the picked files.
+		}
+	}
+	else
+	{
+		// Did not pick any file.
+	}
+}
+-->
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickSpecificFiles"
+										  smtx:XamlDisplayExtensions.Header="Pick specific file types">
+							<Button Content="Open images" Click="PickSpecificFilesButton_Click"/>
+							<!--
+private async void PickSpecificFilesButton_Click(object sender, RoutedEventArgs e)
+{
+	var picker = new FileOpenPicker();
+	picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
+	picker.FileTypeFilter.Add(".jpg");
+	picker.FileTypeFilter.Add(".jpeg");
+	picker.FileTypeFilter.Add(".png");
+	picker.FileTypeFilter.Add(".bmp");
+	var storageFiles = await picker.PickMultipleFilesAsync();
+
+	if (storageFiles != null && storageFiles.Any())
+	{
+		foreach (var file in storageFiles)
+		{
+			var bitmap = new BitmapImage();
+			using (var stream = await file.OpenReadAsync())
+			{
+				await bitmap.SetSourceAsync(stream);
+			}
+			// Display this bitmap.
+		}
+	}
+	else
+	{
+		// Did not pick any file.
+	}
+}
+-->
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickFolder"
+										  smtx:XamlDisplayExtensions.Header="Pick a folder">
+							<Button Content="Open folder" Click="PickFolderButton_Click"/>
+							<!--
+private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
+{
+	var folderPicker = new FolderPicker();
+	folderPicker.FileTypeFilter.Add("*");
+
+	var storageFolder = await folderPicker.PickSingleFolderAsync();
+	if (storageFolder != null)
+	{
+		var fileList = await storageFolder.GetFilesAsync();
+		var folderList = await storageFolder.GetFoldersAsync();
+
+		// Do something with the contents...
+	}
+	else
+	{
+		// Did not pick any folder.
+	}
+}
+-->
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickSaveFile"
+										  smtx:XamlDisplayExtensions.Header="Pick and save to file"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+							<StackPanel Spacing="10">
+								<TextBox PlaceholderText="Type your file contents here..." x:Name="ContentTextBox" />
+								<Button Content="Save to file" Click="SaveFileButton_Click"/>
+								<!--
+private async void SaveFileButton_Click(object sender, RoutedEventArgs e)
+{
+	var picker = new FileSavePicker();
+	picker.FileTypeChoices.Add("Text files", new[] { ".txt" });
+	var storageFile = await picker.PickSaveFileAsync();
+
+	if (storageFile != null)
+	{
+		var textBox = ((sender as Button).Parent as StackPanel)
+			.FindName("ContentTextBox") as TextBox;
+		using (var stream = await storageFile.OpenStreamForWriteAsync())
+		{
+			using (var tw = new StreamWriter(stream))
+			{
+				tw.WriteLine(textBox?.Text);
+			}
+		}
+	}
+	else
+	{
+		// Did not pick any file.
+	}
+}
+-->
+							</StackPanel>
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="FileFolderPickerSamplePage_PickSaveMultipleFiles"
+										  smtx:XamlDisplayExtensions.Header="Pick folder and save to files"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+							<StackPanel Spacing="10">
+								<TextBox PlaceholderText="file1.txt contents..." x:Name="ContentTextBox1" />
+								<TextBox PlaceholderText="file2.txt contents..." x:Name="ContentTextBox2" />
+								<Button Content="Save files" Click="SaveMultipleFilesButton_Click"/>
+								<!--
+private async void SaveMultipleFilesButton_Click(object sender, RoutedEventArgs e)
+{
+	var folderPicker = new FolderPicker();
+	folderPicker.FileTypeFilter.Add("*");
+
+	var storageFolder = await folderPicker.PickSingleFolderAsync();
+	if (storageFolder != null)
+	{
+		var storageFile1 = await storageFolder.CreateFileAsync("file1.txt");
+		var storageFile2 = await storageFolder.CreateFileAsync("file2.txt");
+
+		using (var stream = await storageFile1.OpenStreamForWriteAsync())
+		{
+			// write to file 1...
+		}
+
+		using (var stream = await storageFile2.OpenStreamForWriteAsync())
+		{
+			// write to file 2...
+		}
+	}
+	else
+	{
+		// Did not pick any folder.
+	}
+}
+-->
+							</StackPanel>
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+		</local:SamplePageLayout>
+	</Grid>
+
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Windows.Storage.Pickers;
+using Windows.UI.Popups;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Uno.Gallery.Views.Samples
+{
+	[SamplePage(SampleCategory.Features, "File and Folder Pickers", Description = "A file picker displays information to orient users and provide a consistent experience when opening or saving files.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/uwp/files/quickstart-using-file-and-folder-pickers")]
+	public sealed partial class FileFolderPickerSamplePage : Page
+	{
+		public FileFolderPickerSamplePage()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void PickFileButton_Click(object sender, RoutedEventArgs e)
+		{
+			var picker = new FileOpenPicker();
+			picker.FileTypeFilter.Add("*");
+			var storageFile = await picker.PickSingleFileAsync();
+
+			if (storageFile != null)
+			{
+				await new MessageDialog(storageFile.Path, "Successfully picked file").ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any file!", "Failed to pick file").ShowAsync();
+			}
+		}
+
+		private async void PickMultipleFilesButton_Click(object sender, RoutedEventArgs e)
+		{
+			var picker = new FileOpenPicker();
+			picker.FileTypeFilter.Add("*");
+			var storageFiles = await picker.PickMultipleFilesAsync();
+
+			if (storageFiles?.Any() ?? false)
+			{
+				var fileListString = string.Join(Environment.NewLine, storageFiles.Select(f => f.Path));
+				var dialog = new ContentDialog()
+				{
+					Title = "Successfully picked files",
+					Content = new ScrollViewer()
+					{
+						Content = new TextBlock() { Text = fileListString }
+					},
+					PrimaryButtonText = "OK"
+				};
+				await dialog.ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any file!", "Failed to pick files").ShowAsync();
+			}
+		}
+
+		private async void PickSpecificFilesButton_Click(object sender, RoutedEventArgs e)
+		{
+			var picker = new FileOpenPicker();
+			picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
+			picker.FileTypeFilter.Add(".jpg");
+			picker.FileTypeFilter.Add(".jpeg");
+			picker.FileTypeFilter.Add(".png");
+			picker.FileTypeFilter.Add(".bmp");
+			var storageFiles = await picker.PickMultipleFilesAsync();
+
+			if (storageFiles?.Any() ?? false)
+			{
+				var stack = new StackPanel() { Spacing = 10 };
+				foreach (var file in storageFiles)
+				{
+					var bitmap = new BitmapImage();
+					using (var stream = await file.OpenReadAsync())
+					{
+						await bitmap.SetSourceAsync(stream);
+					}
+					stack.Children.Add(new Image() { Source = bitmap });
+				}
+				var dialog = new ContentDialog()
+				{
+					Title = "Successsfully picked images",
+					Content = new ScrollViewer() { Content = stack },
+					PrimaryButtonText = "OK"
+				};
+				await dialog.ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any image!", "Failed to pick images").ShowAsync();
+			}
+		}
+
+		private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
+		{
+			var folderPicker = new FolderPicker();
+			folderPicker.FileTypeFilter.Add("*");
+
+			var storageFolder = await folderPicker.PickSingleFolderAsync();
+			if (storageFolder != null)
+			{
+				var fileList = await storageFolder.GetFilesAsync();
+				var folderList = await storageFolder.GetFoldersAsync();
+
+				var contentString = string.Join(Environment.NewLine, 
+					fileList.Select(f => f.Path).Concat(folderList.Select(f => f.Path)));
+				var dialog = new ContentDialog()
+				{
+					Title = "Contents of picked folder",
+					Content = new ScrollViewer() 
+					{ 
+						Content = new TextBlock() { Text = contentString } 
+					},
+					PrimaryButtonText = "OK"
+				};
+				await dialog.ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any folder!", "Failed to pick folder").ShowAsync();
+			}
+		}
+
+		private async void SaveFileButton_Click(object sender, RoutedEventArgs e)
+		{
+			var picker = new FileSavePicker();
+			picker.FileTypeChoices.Add("Text files", new[] { ".txt" });
+			var storageFile = await picker.PickSaveFileAsync();
+
+			if (storageFile != null)
+			{
+				var textBox = ((sender as Button).Parent as StackPanel)
+					.FindName("ContentTextBox") as TextBox;
+				using (var stream = await storageFile.OpenStreamForWriteAsync())
+				{
+					using (var tw = new StreamWriter(stream))
+					{
+						tw.WriteLine(textBox?.Text);
+					}
+				}
+				await new MessageDialog(storageFile.Path, "Successfully saved to file").ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any file!", "Failed to save to file").ShowAsync();
+			}
+		}
+
+		private async void SaveMultipleFilesButton_Click(object sender, RoutedEventArgs e)
+		{
+			var folderPicker = new FolderPicker();
+			folderPicker.FileTypeFilter.Add("*");
+
+			var storageFolder = await folderPicker.PickSingleFolderAsync();
+			if (storageFolder != null)
+			{
+				var storageFile1 = await storageFolder.CreateFileAsync("file1.txt");
+				var storageFile2 = await storageFolder.CreateFileAsync("file2.txt");
+
+				var textBox1 = ((sender as Button).Parent as StackPanel)
+					.FindName("ContentTextBox1") as TextBox;
+				var textBox2 = ((sender as Button).Parent as StackPanel)
+					.FindName("ContentTextBox2") as TextBox;
+
+				using (var stream = await storageFile1.OpenStreamForWriteAsync())
+				{
+					using (var tw = new StreamWriter(stream))
+					{
+						tw.WriteLine(textBox1?.Text);
+					}
+				}
+
+				using (var stream = await storageFile2.OpenStreamForWriteAsync())
+				{
+					using (var tw = new StreamWriter(stream))
+					{
+						tw.WriteLine(textBox2?.Text);
+					}
+				}
+
+				await new MessageDialog(storageFolder.Path, "Successfully saved files to folder").ShowAsync();
+			}
+			else
+			{
+				await new MessageDialog("You didn't pick any folder!", "Failed to save files").ShowAsync();
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #465 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No sample page for file and folder pickers.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

A File and Folder Picker sample page has been added.
The sample page includes:
- Opening and saving files in several different scenarios:
  + Opening a single file.
  + Opening multiple files.
  + Opening files of a specific type.
  + Opening a folder.
  + Saving to a file.
  + Saving to multiple files in a folder.
- Code snippets. The code snippets include C# event handlers. The C# code is simplified to allow the user to focus on the UWP File APIs.

![image](https://user-images.githubusercontent.com/57174311/193437208-4534ac5d-34d6-4cab-99a8-f32218533e56.png)
![image](https://user-images.githubusercontent.com/57174311/193437210-271d48f5-54bd-447c-adaa-e06d15b2db89.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
