### PR TITLE
feat: Add Accelerometer sample page

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -199,6 +199,9 @@
     <Compile Include="Views\NestedPages\NavigationBarSample_NestedPage2.xaml.cs">
       <DependentUpon>NavigationBarSample_NestedPage2.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\AccelerometerSamplePage.xaml.cs">
+      <DependentUpon>AccelerometerSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\AcrylicSamplePage.xaml.cs">
       <DependentUpon>AcrylicSamplePage.xaml</DependentUpon>
     </Compile>
@@ -460,6 +463,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\NestedPages\NavigationBarSample_NestedPage2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\AccelerometerSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml
@@ -1,0 +1,96 @@
+﻿<Page
+	x:Class="Uno.Gallery.Views.Samples.AccelerometerSamplePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.Gallery"
+	xmlns:samples="using:Uno.Gallery.Views.Samples"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:smtx="using:ShowMeTheXAML"
+	mc:Ignorable="d">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<smtx:XamlDisplay UniqueKey="AccelerometerSamplePage_Sample"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+										  smtx:XamlDisplayExtensions.Header="Accelerometer">
+							<StackPanel Spacing="20">
+								<!-- C# code
+var accelerometer = Accelerometer.GetDefault();
+			
+if (accelerometer != null)
+{
+	accelerometer.Shaken += Accelerometer_Shaken;
+	accelerometer.ReadingChanged += Accelerometer_ReadingChanged;
+}
+else
+{
+	// Accelerometer is not available on this platform/device.
+}
+
+private void Accelerometer_Shaken(Accelerometer sender, AccelerometerShakenEventArgs args)
+{
+	LastShakeTimestamp = args.Timestamp;
+	++ShakeCount;
+}
+
+private void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
+{
+	LastReadTimestamp = args.Reading.Timestamp;
+	AccelerationX = args.Reading.AccelerationX;
+	AccelerationY = args.Reading.AccelerationY;
+	AccelerationZ = args.Reading.AccelerationZ;
+}
+-->
+								
+								<StackPanel.DataContext>
+									<samples:AccelerometerSamplePageViewModel />
+								</StackPanel.DataContext>
+
+								<TextBlock>
+									<LineBreak />
+									<Span>Device shaked </Span>
+									<Run Text="{Binding ShakeCount}" />
+									<Span> time(s).</Span>
+									<LineBreak />
+									<Span FontWeight="Bold">Last shake timestamp: </Span>
+									<Run Text="{Binding LastShakeTimestamp}" />
+								</TextBlock>
+
+								<TextBlock>
+									<LineBreak />
+									<Span FontWeight="Bold">Acceleration X: </Span>
+									<Run Text="{Binding AccelerationX}" />
+									<LineBreak />
+									<Span FontWeight="Bold">Acceleration Y: </Span>
+									<Run Text="{Binding AccelerationY}" />
+									<LineBreak />
+									<Span FontWeight="Bold">Acceleration Z: </Span>
+									<Run Text="{Binding AccelerationZ}" />
+									<LineBreak />
+									<Span FontWeight="Bold">Last read timestamp: </Span>
+									<Run Text="{Binding LastReadTimestamp}" />
+								</TextBlock>
+
+								<muxc:NumberBox Value="{Binding ReportInterval, Mode=TwoWay}"
+												Header="Report Interval (milliseconds)"
+												IsEnabled="{Binding AccelerometerAvailable}"
+												SpinButtonPlacementMode="Inline" />
+
+								<Button IsEnabled="{Binding AccelerometerAvailable}" Click="ObserveReadingChangeButton_Click">
+									<TextBlock Text="{Binding ButtonContent}" VerticalAlignment="Stretch" TextAlignment="Center" />
+								</Button>
+							</StackPanel>
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+
+		</local:SamplePageLayout>
+	</Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.ComponentModel;
+using Windows.Devices.Sensors;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.Gallery.Views.Samples
+{
+	[SamplePage(SampleCategory.Features, "Accelerometer", Description = "Represents an accelerometer sensor. This sensor returns G-force values with respect to the x, y, and z axes.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/uwp/devices-sensors/use-the-accelerometer")]
+	public sealed partial class AccelerometerSamplePage : Page
+	{
+		public AccelerometerSamplePage()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ObserveReadingChangeButton_Click(object sender, RoutedEventArgs e)
+		{
+			if ((sender as Button)?.DataContext is AccelerometerSamplePageViewModel viewModel)
+			{
+				if (!viewModel.ObservingReadingChange)
+				{
+					viewModel.StartObserveReadingChange();
+				}
+				else
+				{
+					viewModel.StopObservingReadingChange();
+				}
+			}
+		}
+	}
+
+	public class AccelerometerSamplePageViewModel: INotifyPropertyChanged
+	{
+		private const string _startObservingContent = "Start observing accelerometer reading changes";
+		private const string _stopObservingContent = "Stop observing accelerometer reading changes";
+
+		private readonly Accelerometer _accelerometer;
+		private uint _shakeCount = 0;
+		private DateTimeOffset? _lastShakeTimestamp;
+		private DateTimeOffset? _lastReadTimestamp;
+		private string _buttonContent = "Accelerometer is not available on this device/platform";
+		private bool _observingReadingChange = false;
+		private double _accelerationX;
+		private double _accelerationY;
+		private double _accelerationZ;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public uint? ReportInterval
+		{
+			get => _accelerometer?.ReportInterval;
+			set
+			{
+				if (_accelerometer != null && value != null)
+				{
+					_accelerometer.ReportInterval = (uint)value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ReportInterval)));
+				}
+			}
+		}
+
+		public uint ShakeCount
+		{
+			get => _shakeCount;
+			set
+			{
+				_shakeCount = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShakeCount)));
+			}
+		}
+
+		public DateTimeOffset? LastShakeTimestamp
+		{
+			get => _lastShakeTimestamp;
+			set
+			{
+				_lastShakeTimestamp = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LastShakeTimestamp)));
+			}
+		}
+		
+		public DateTimeOffset? LastReadTimestamp
+		{
+			get => _lastReadTimestamp;
+			set
+			{
+				_lastReadTimestamp = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LastReadTimestamp)));
+			}
+		}
+
+		public string ButtonContent
+		{
+			get => _buttonContent;
+			set
+			{
+				_buttonContent = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ButtonContent)));
+			}
+		}
+
+		public bool ObservingReadingChange
+		{
+			get => _observingReadingChange;
+			set
+			{
+				_observingReadingChange = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ObservingReadingChange)));
+			}
+		}
+
+		public double AccelerationX
+		{
+			get => _accelerationX;
+			set
+			{
+				_accelerationX = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AccelerationX)));
+			}
+		}
+
+		public double AccelerationY
+		{
+			get => _accelerationY;
+			set
+			{
+				_accelerationY = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AccelerationY)));
+			}
+		}
+
+		public double AccelerationZ
+		{
+			get => _accelerationZ;
+			set
+			{
+				_accelerationZ = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AccelerationZ)));
+			}
+		}
+
+		public bool AccelerometerAvailable => _accelerometer != null;
+
+		public AccelerometerSamplePageViewModel()
+		{
+			_accelerometer = Accelerometer.GetDefault();
+			
+			if (_accelerometer != null)
+			{
+				_accelerometer.Shaken += Accelerometer_Shaken;
+				ButtonContent = _startObservingContent;
+			}
+		}
+
+		public void StartObserveReadingChange()
+		{
+			_accelerometer.ReadingChanged += Accelerometer_ReadingChanged;
+			ButtonContent = _stopObservingContent;
+			ObservingReadingChange = true;
+		}
+
+		public void StopObservingReadingChange()
+		{
+			_accelerometer.ReadingChanged -= Accelerometer_ReadingChanged;
+			ButtonContent = _startObservingContent;
+			ObservingReadingChange = false;
+		}
+
+		private void Accelerometer_Shaken(Accelerometer sender, AccelerometerShakenEventArgs args)
+		{
+			LastShakeTimestamp = args.Timestamp;
+			++ShakeCount;
+		}
+
+		private void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
+		{
+			LastReadTimestamp = args.Reading.Timestamp;
+			AccelerationX = args.Reading.AccelerationX;
+			AccelerationY = args.Reading.AccelerationY;
+			AccelerationZ = args.Reading.AccelerationZ;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #463 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one ore more that apply to this PR -->

## What is the current behavior?

No sample page for `Accelerometer`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

A sample page for `Accelerometer` has been added.
The sample page includes:

- Demonstrations for Accelerometer APIs that are implemented in Uno: `GetDefault()`, `ReportInterval`, `Shaken` and `ReadingChanged`. Other APIs that are available in UWP but not Uno are left out.
- A basic C# code snippet that demonstrates the use of `GetDefault()` and the two events.

<!-- Please describe the new behavior after your modifications. -->

On an Android 12 phone:
![image](https://user-images.githubusercontent.com/57174311/193444741-79225fe9-c4c8-4d9a-9beb-b933f6d6d26e.png)

On a Windows 11 PC:
![image](https://user-images.githubusercontent.com/57174311/193444752-54c7ae4c-0bd0-4b90-b9e0-cbc9329b3c92.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
