### PR TITLE
fix: Safe area bounds don't respect Window bounds changes

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/Shell.xaml.cs
@@ -70,15 +70,14 @@ namespace Uno.Gallery
 		/// </summary>
 		private void InitializeSafeArea()
 		{
-			var full = Windows.UI.Xaml.Window.Current.Bounds;
-
-            ApplicationView.GetForCurrentView().VisibleBoundsChanged += (s, e) => Adjust();
+			ApplicationView.GetForCurrentView().VisibleBoundsChanged += (s, e) => Adjust();
 
 			Adjust();
 
 			void Adjust()
 			{
-				var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+                var full = Windows.UI.Xaml.Window.Current.Bounds;
+                var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
 				var topPadding = Math.Abs(full.Top - bounds.Top);
 
 				if (topPadding > 0)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #512

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Safe area calculation does not use updated window bounds, which means that window size change cause the resulting top padding to be non-sensical


## What is the new behavior?

Use current window bounds always.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
