### PR TITLE
feat: Add Geolocator sample page

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Droid/Properties/AndroidManifest.xml
+++ b/Uno.Gallery/Uno.Gallery.Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nventive.uno.ui.demo" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nventive.uno.ui.demo" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:label="Uno Gallery" android:icon="@mipmap/ic_launcher"></application>
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+	<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
 </manifest>

--- a/Uno.Gallery/Uno.Gallery.UWP/Package.appxmanifest
+++ b/Uno.Gallery/Uno.Gallery.UWP/Package.appxmanifest
@@ -45,5 +45,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <DeviceCapability Name="location"/>
   </Capabilities>
 </Package>

--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -214,6 +214,9 @@
     <Compile Include="Views\SamplePages\ClipboardSamplePage.xaml.cs">
       <DependentUpon>ClipboardSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\GeolocatorSamplePage.xaml.cs">
+      <DependentUpon>GeolocatorSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\RefreshContainerPage.xaml.cs">
       <DependentUpon>RefreshContainerPage.xaml</DependentUpon>
     </Compile>
@@ -492,6 +495,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\SamplePages\ClipboardSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\GeolocatorSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml
@@ -1,0 +1,70 @@
+﻿<Page
+    x:Class="Uno.Gallery.Views.Samples.GeolocatorSamplePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.Gallery"
+	xmlns:samples="using:Uno.Gallery.Views.Samples"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:smtx="using:ShowMeTheXAML"
+	mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <local:SamplePageLayout>
+
+            <local:SamplePageLayout.FluentTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <smtx:XamlDisplay UniqueKey="GeolocatorSamplePage_Sample"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+										  smtx:XamlDisplayExtensions.Header="Geolocator">
+                            <StackPanel Spacing="20">
+                                <StackPanel.DataContext>
+                                    <samples:GeolocatorSamplePageViewModel />
+                                </StackPanel.DataContext>
+
+                                <TextBlock>
+                                    <Span>Tap to see your current GPS coordinates.</Span>
+                                </TextBlock>
+
+                                <Button Click="GetGeopositionButton_Click">
+                                    <TextBlock Text="{Binding ButtonContent}" VerticalAlignment="Stretch" TextAlignment="Center" />
+                                </Button>
+
+                                <TextBlock>
+                                    <Span>Tap to toggle the geoposition location changed tracker.</Span>
+                                </TextBlock>
+                                
+                                <Button Click="ToggleGeopositionButton_Click">
+                                    <TextBlock Text="{Binding ToggleButtonContent}" VerticalAlignment="Stretch" TextAlignment="Center" />
+                                </Button>
+
+                                <TextBlock>
+                                    <LineBreak />
+                                    <Span>Latitude: </Span>
+                                    <Run Text="{Binding GeolocatedLatitude}" />
+                                    <LineBreak />
+                                    <Span>Longitude: </Span>
+                                    <Run Text="{Binding GeolocatedLongitude}" />
+                                    <LineBreak />
+                                    <Span>Altitude: </Span>
+                                    <Run Text="{Binding GeolocatedAltitude}" />
+                                    <Span> m</Span>
+                                    <LineBreak />
+                                    <Span>Accuracy: </Span>
+                                    <Run Text="{Binding GeolocatedAccuracy}" />
+                                    <Span> m</Span>
+                                    <LineBreak />
+                                    <Span>Timestamp: </Span>
+                                    <Run Text="{Binding GeolocatedTimestamp}" />
+                                </TextBlock>
+                                
+                            </StackPanel>
+                        </smtx:XamlDisplay>
+                    </StackPanel>
+                </DataTemplate>
+            </local:SamplePageLayout.FluentTemplate>
+        </local:SamplePageLayout>
+    </Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.ComponentModel;
+using Uno.Extensions;
+using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.Store;
+using Windows.Devices.Geolocation;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.Gallery.Views.Samples
+{
+    [SamplePage(SampleCategory.Features, "Geolocator", Description = "Represents a geolocator sensor. This sensor returns latitude, longitude, longitude and accuracy.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/windows.devices.geolocation.geolocator")]
+    public sealed partial class GeolocatorSamplePage : Page
+    {
+        public GeolocatorSamplePage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void GetGeopositionButton_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as Button)?.DataContext is GeolocatorSamplePageViewModel viewModel)
+            {
+                viewModel.GetGeoposition();
+            }
+        }
+
+        private void ToggleGeopositionButton_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as Button)?.DataContext is GeolocatorSamplePageViewModel viewModel)
+            {
+                viewModel.ToggleTracker();
+            }
+        }
+    }
+
+    public class GeolocatorSamplePageViewModel : INotifyPropertyChanged
+    {
+        private Geolocator _geolocator;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private bool _isTracking = false;
+        public bool IsTracking
+        {
+            get => _isTracking;
+            set
+            {
+                _isTracking = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsTracking)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ToggleButtonContent)));
+            }
+        }
+        public string ButtonContent => "Get geoposition";
+        public string ToggleButtonContent => _isTracking ? "Stop tracking" : "Start tracking";
+
+        private double? _GeolocatedLatitude;
+        public double? GeolocatedLatitude
+        {
+            get => _GeolocatedLatitude;
+            set
+            {
+                _GeolocatedLatitude = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeolocatedLatitude)));
+            }
+        }
+        
+        private double? _GeolocatedLongitude;
+        public double? GeolocatedLongitude
+        {
+            get => _GeolocatedLongitude;
+            set
+            {
+                _GeolocatedLongitude = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeolocatedLongitude)));
+            }
+        }
+        
+        private double? _GeolocatedAltitude;
+        public double? GeolocatedAltitude
+        {
+            get => _GeolocatedAltitude;
+            set
+            {
+                _GeolocatedAltitude = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeolocatedAltitude)));
+            }
+        }
+        
+        private double? _GeolocatedAccuracy;
+        public double? GeolocatedAccuracy
+        {
+            get => _GeolocatedAccuracy;
+            set
+            {
+                _GeolocatedAccuracy = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeolocatedAccuracy)));
+            }
+        }
+        
+        private DateTime _GeolocatedTimestamp;
+        public DateTime GeolocatedTimestamp
+        {
+            get => _GeolocatedTimestamp;
+            set
+            {
+                _GeolocatedTimestamp = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeolocatedTimestamp)));
+            }
+        }
+
+        public GeolocatorSamplePageViewModel()
+        {
+            _geolocator = new Geolocator();
+        }
+
+        public async void GetGeoposition()
+        {
+            var accessStatus = await Geolocator.RequestAccessAsync();
+            switch(accessStatus)
+            {
+                case GeolocationAccessStatus.Allowed:
+                    var geoposition = await _geolocator.GetGeopositionAsync();
+                    UpdateGeolocation(geoposition);
+                    break;
+                case GeolocationAccessStatus.Denied:
+                    ShowMessageGeolocationAccessDenied();
+                    break;
+                case GeolocationAccessStatus.Unspecified:
+                    ShowMessageGeolocationAccessUnspecified();
+                    break;
+            }
+        }
+
+        public async void ToggleTracker()
+        {
+            var accessStatus = await Geolocator.RequestAccessAsync();
+            switch(accessStatus)
+            {
+                case GeolocationAccessStatus.Allowed:
+                    if (IsTracking)
+                        _geolocator.PositionChanged -= _geolocator_PositionChanged;
+                    else
+                        _geolocator.PositionChanged += _geolocator_PositionChanged;
+                    IsTracking = !IsTracking;
+                    break;
+                case GeolocationAccessStatus.Denied:
+                    ShowMessageGeolocationAccessDenied();
+                    break;
+                case GeolocationAccessStatus.Unspecified:
+                    ShowMessageGeolocationAccessUnspecified();
+                    break;
+            }
+        }
+
+        private async void _geolocator_PositionChanged(Geolocator sender, PositionChangedEventArgs args)
+        {
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                UpdateGeolocation(args.Position);
+            });
+        }
+
+        private async void ShowMessageGeolocationAccessDenied()
+        {
+            // Code to handle access to location services denied.
+        }
+
+        private async void ShowMessageGeolocationAccessUnspecified()
+        {
+            // Code to handle access to location services with unspecified status.
+        }
+
+        private void UpdateGeolocation(Geoposition position)
+        {
+            GeolocatedAccuracy = position.Coordinate.Accuracy;
+            GeolocatedAltitude = position.Coordinate.Point.Position.Altitude;
+            GeolocatedLatitude = position.Coordinate.Point.Position.Latitude;
+            GeolocatedLongitude = position.Coordinate.Point.Position.Longitude;
+            GeolocatedTimestamp = DateTime.Now;
+        }
+    }
+}

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
-    [SamplePage(SampleCategory.Features, "Geolocator", Description = "Represents a geolocator sensor. This sensor returns latitude, longitude, longitude and accuracy.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/windows.devices.geolocation.geolocator")]
+    [SamplePage(SampleCategory.NonUIFeatures, "Geolocator", Description = "Represents a geolocator sensor. This sensor returns latitude, longitude, longitude and accuracy.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/windows.devices.geolocation.geolocator")]
     public sealed partial class GeolocatorSamplePage : Page
     {
         public GeolocatorSamplePage()

--- a/Uno.Gallery/Uno.Gallery.iOS/Info.plist
+++ b/Uno.Gallery/Uno.Gallery.iOS/Info.plist
@@ -61,5 +61,9 @@
 	<string>Media.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>
 	<string>Media.xcassets/LaunchImages.launchimage</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The location access is required to test the location functionality</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The location access is required to test the location functionality</string>
 </dict>
 </plist>

--- a/Uno.Gallery/Uno.Gallery.macOS/Info.plist
+++ b/Uno.Gallery/Uno.Gallery.macOS/Info.plist
@@ -28,5 +28,7 @@
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>Fonts</string>
+  <key>NSLocationUsageDescription</key>
+  <string>The location access is required to test the location functionality</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds the Geolocator sample page.

Includes changes in AndroidManifest.xml, iOS Info.plist and macOS Info.plist, UWP Package.appxmanifest, in order to be able to use the location services in each platform.

GitHub Issue (If applicable): #462 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

Feature

## What is the current behavior?

No sample page for Geolocator


## What is the new behavior?

A sample page for Geolocator has been added.
The sample page includes a demonstration of basic Geolocator usage (with one-time location access and with a monitor on the Geolocator position changed event).

On Android 12 emulator:
![uno-geolocator-android](https://user-images.githubusercontent.com/5546544/194797100-3494480f-5cee-46ee-b50e-4a3c1d082173.gif)

On Windows 11 PC:
![uno-geolocator-uwp](https://user-images.githubusercontent.com/5546544/194797130-f1141023-2d80-4139-8d88-2658b40d1d54.png)

On WASM:
![uno-geolocator-wasm](https://user-images.githubusercontent.com/5546544/194797143-d6219629-1b01-44e7-92f3-dab1ce6a2191.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
