### PR TITLE
feat: Add `VibrationDevice'-sample

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -205,6 +205,9 @@
     <Compile Include="Views\SamplePages\AcrylicSamplePage.xaml.cs">
       <DependentUpon>AcrylicSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\VibrationDeviceSamplePage.xaml.cs">
+      <DependentUpon>VibrationDeviceSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\PasswordVaultSamplePage.xaml.cs">
       <DependentUpon>PasswordVaultSamplePage.xaml</DependentUpon>
     </Compile>
@@ -482,6 +485,10 @@
     <Page Include="Views\SamplePages\AcrylicSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\VibrationDeviceSamplePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\SamplePages\PasswordVaultSamplePage.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/VibrationDeviceSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/VibrationDeviceSamplePage.xaml
@@ -1,0 +1,55 @@
+﻿<Page x:Class="Uno.Gallery.Views.Samples.VibrationDeviceSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Gallery"
+	  xmlns:samples="using:Uno.Gallery.Views.Samples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:ios="http://uno.ui/ios"
+	  xmlns:macos="http://uno.ui/macos"
+	  xmlns:skia="http://uno.ui/skia"
+	  xmlns:wasm="http://uno.ui/wasm"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  mc:Ignorable="d android ios macos skia wasm"
+	  x:Name="page">
+
+    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<smtx:XamlDisplay UniqueKey="VibrationDeviceSamplePage_Text"
+										  smtx:XamlDisplayExtensions.Header="Vibration"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+                            <StackPanel Spacing="8">
+                                <Button Content="Vibrate for 100ms" Click="Vibrate100_Click"/>
+                                <Button Content="Vibrate for 1000ms" Click="Vibrate1000_Click"/>
+                                <!--
+	private void Vibrate100_Click(object sender, RoutedEventArgs args)
+	{
+		var vibrationDevice = VibrationDevice.GetDefault();
+		if(vibrationDevice != null)
+		{
+			vibrationDevice.Vibrate(TimeSpan.FromMilliseconds(100));
+		}
+	}
+
+	private async void Vibrate1000_Click(object sender, RoutedEventArgs args)
+	{
+		var vibrationDevice = VibrationDevice.GetDefault();
+		if(vibrationDevice != null)
+		{
+			vibrationDevice.Vibrate(TimeSpan.FromMilliseconds(1000));
+		}
+	}
+-->
+                            </StackPanel>
+                        </smtx:XamlDisplay>
+                    </StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+		</local:SamplePageLayout>
+	</Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/VibrationDeviceSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/VibrationDeviceSamplePage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.Phone.Devices.Notification;
+
+namespace Uno.Gallery.Views.Samples
+{
+	[SamplePage(SampleCategory.NonUIFeatures, "Vibration", Description = "Activates the vibration device for a certain amount of time.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/windows.devices.haptics.vibrationdevice")]
+    public sealed partial class VibrationDeviceSamplePage : Page
+	{
+        public VibrationDeviceSamplePage()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Vibrate100_Click(object sender, RoutedEventArgs args)
+		{
+			var vibrationDevice = VibrationDevice.GetDefault();
+			if (vibrationDevice != null)
+			{
+				vibrationDevice.Vibrate(TimeSpan.FromMilliseconds(1000));
+			}
+		}
+
+		private void Vibrate1000_Click(object sender, RoutedEventArgs args)
+		{
+			var vibrationDevice = VibrationDevice.GetDefault();
+			if (vibrationDevice != null)
+			{
+				vibrationDevice.Vibrate(TimeSpan.FromMilliseconds(1000));
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #472 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->
- Sample

## What is the current behavior?

There is no sample for `VibrationDevice`.


## What is the new behavior?

There is a sample for `VibrationDevice`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Currently I cannot build the solution with my change as `VibrationDevice` is not available. Not sure if this is related to my local build environment or if I am missing something here.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
