### PR TITLE
fix: GeolocatorSamplePage null check on UpdateGeolocation

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GeolocatorSamplePage.xaml.cs
@@ -157,7 +157,7 @@ namespace Uno.Gallery.Views.Samples
         {
             await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                UpdateGeolocation(args.Position);
+                UpdateGeolocation(args?.Position);
             });
         }
 
@@ -173,10 +173,10 @@ namespace Uno.Gallery.Views.Samples
 
         private void UpdateGeolocation(Geoposition position)
         {
-            GeolocatedAccuracy = position.Coordinate.Accuracy;
-            GeolocatedAltitude = position.Coordinate.Point.Position.Altitude;
-            GeolocatedLatitude = position.Coordinate.Point.Position.Latitude;
-            GeolocatedLongitude = position.Coordinate.Point.Position.Longitude;
+            GeolocatedAccuracy = position?.Coordinate?.Accuracy;
+            GeolocatedAltitude = position?.Coordinate?.Point?.Position.Altitude;
+            GeolocatedLatitude = position?.Coordinate?.Point?.Position.Latitude;
+            GeolocatedLongitude = position?.Coordinate?.Point?.Position.Longitude;
             GeolocatedTimestamp = DateTime.Now;
         }
     }


### PR DESCRIPTION
Adds null checks to the properties used in the UpdateLocation method to avoid NullReferenceException when the location is null.

GitHub Issue (If applicable): #462 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In some cases the location is null, generating a NullReferenceException.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Prevents the NullReferenceException.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->