### PR TITLE
feat: Add RatingControlSamplePage

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
+++ b/Uno.Gallery/Uno.Gallery.UWP/Uno.Gallery.UWP.csproj
@@ -199,6 +199,9 @@
     <Compile Include="Views\NestedPages\NavigationBarSample_NestedPage2.xaml.cs">
       <DependentUpon>NavigationBarSample_NestedPage2.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SamplePages\RatingControlSamplePage.xaml.cs">
+      <DependentUpon>RatingControlSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SamplePages\AccelerometerSamplePage.xaml.cs">
       <DependentUpon>AccelerometerSamplePage.xaml</DependentUpon>
     </Compile>
@@ -474,6 +477,10 @@
     <Page Include="Views\NestedPages\NavigationBarSample_NestedPage2.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SamplePages\RatingControlSamplePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\SamplePages\AccelerometerSamplePage.xaml">
       <SubType>Designer</SubType>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml
@@ -1,0 +1,64 @@
+﻿<Page
+	x:Class="Uno.Gallery.Views.Samples.RatingControlSamplePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.Gallery"
+	xmlns:samples="using:Uno.Gallery.Views.Samples"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:smtx="using:ShowMeTheXAML"
+	mc:Ignorable="d">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<smtx:XamlDisplay UniqueKey="RatingControlSamplePage_Sample"
+										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
+										  smtx:XamlDisplayExtensions.Header="Rating Control">
+							<StackPanel Spacing="20">
+								<muxc:RatingControl Value="{Binding Data.RatingControlValue, Mode=TwoWay}"
+											   MaxRating="{Binding Data.MaxRating}"
+											   IsReadOnly="{Binding Data.IsReadOnly}"
+											   IsClearEnabled="{Binding Data.IsClearEnabled}"
+											   Caption="{Binding Data.Caption}"
+											   CanDrag="{Binding Data.CanDrag}"/>
+
+								<utu:Divider SubHeader="Test the RatingControl parameters"
+									Style="{StaticResource DividerStyle}"
+									xmlns:utu="using:Uno.Toolkit.UI" />
+								<StackPanel Orientation="Horizontal">
+									<TextBlock>
+										<Run Text="Current value: " />
+										<Run Text="{Binding Data.RatingControlValue}" />
+									</TextBlock>
+									<Button Content="-1" Command="{Binding Data.Minus1Command}" Margin="10,0,0,0" />
+									<Button Content="Clear" Command="{Binding Data.ClearCommand}" Margin="10,0,0,0" />
+									<Button Content="+1" Command="{Binding Data.Plus1Command}" Margin="10,0,0,0" />
+								</StackPanel>
+
+								<TextBlock>
+									<Run Text="Max Rating: " />
+									<Run Text="{Binding Data.MaxRating}" />
+								</TextBlock>
+								<Slider Value="{Binding Data.MaxRating, Mode=TwoWay}" Minimum="1" Maximum="15" />
+
+								<CheckBox Content="Is read only" IsChecked="{Binding Data.IsReadOnly, Mode=TwoWay}" />
+
+								<CheckBox Content="Is clear enabled" IsChecked="{Binding Data.IsClearEnabled, Mode=TwoWay}" />
+
+								<TextBox Header="Caption" Text="{Binding Data.Caption, Mode=TwoWay}" />
+
+								<CheckBox Content="Can drag" IsChecked="{Binding Data.CanDrag, Mode=TwoWay}" />
+							</StackPanel>
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+
+		</local:SamplePageLayout>
+	</Grid>
+</Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
-	[SamplePage(SampleCategory.Toolkit, "RatingControl",
+	[SamplePage(SampleCategory.UIComponents, "RatingControl",
 		Description = "A control to display rating points with stars.",
 		DocumentationLink = "https://platform.uno/docs/articles/external/figma-docs/components/rating-control.html",
 		DataType = typeof(RatingControlSamplePageViewModel))]

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/RatingControlSamplePage.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.ComponentModel;
+using System.Data;
+using System.Windows.Input;
+using Uno.Gallery.ViewModels;
+using Windows.Devices.Sensors;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.Gallery.Views.Samples
+{
+	[SamplePage(SampleCategory.Toolkit, "RatingControl",
+		Description = "A control to display rating points with stars.",
+		DocumentationLink = "https://platform.uno/docs/articles/external/figma-docs/components/rating-control.html",
+		DataType = typeof(RatingControlSamplePageViewModel))]
+	public sealed partial class RatingControlSamplePage : Page
+	{
+		public RatingControlSamplePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public class RatingControlSamplePageViewModel : ViewModelBase
+	{
+		public int MaxRating { get => GetProperty<int>(); set => SetProperty(value); }
+		public bool IsReadOnly { get => GetProperty<bool>(); set => SetProperty(value); }
+		public bool IsClearEnabled { get => GetProperty<bool>(); set => SetProperty(value); }
+		public string Caption { get => GetProperty<string>(); set => SetProperty(value); }
+		public double RatingControlValue { get => GetProperty<double>(); set => SetProperty(value); }
+		public bool CanDrag { get => GetProperty<bool>(); set => SetProperty(value); }
+		public ICommand Minus1Command => new Command(Minus1);
+		public ICommand ClearCommand => new Command(Clear);
+		public ICommand Plus1Command => new Command(Plus1);
+		public RatingControlSamplePageViewModel()
+		{
+			MaxRating = 5;
+			IsReadOnly = false;
+			IsClearEnabled = false;
+			Caption = "";
+			RatingControlValue = 3;
+			CanDrag = false;
+		}
+
+		public void Minus1()
+		{
+			RatingControlValue--;
+			if (RatingControlValue < 1) RatingControlValue = IsClearEnabled ? -1 : 1;
+		}
+		public void Clear()
+		{
+			RatingControlValue = IsClearEnabled ? -1 : 1;
+		}
+		public void Plus1()
+		{
+			RatingControlValue++;
+			if (RatingControlValue > MaxRating) RatingControlValue = MaxRating;
+			if (RatingControlValue == 0) RatingControlValue = 1;
+		}
+	}
+}


### PR DESCRIPTION
Adds the sample page for the RatingControl.

GitHub Issue (If applicable): #448 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No sample page for RatingControl.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
A sample page for RatingControl has been added.

On Android 12 emulator:
![RatingControl_Android](https://user-images.githubusercontent.com/5546544/197661689-451fe525-a044-4021-9525-62d1f3fa773d.gif)

On Windows 11 PC:
![RatingControl_UWP](https://user-images.githubusercontent.com/5546544/197661676-15ef80bd-63cb-4101-96d0-e689d1286726.png)

On WASM:
![RatingControl_WASM](https://user-images.githubusercontent.com/5546544/197661643-ef4af73a-3567-4fc7-843a-5fddde653673.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
