### PR TITLE
fix: Fix PickSaveMultipleFiles crashing app

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml
@@ -169,8 +169,8 @@ private async void SaveMultipleFilesButton_Click(object sender, RoutedEventArgs 
 	var storageFolder = await folderPicker.PickSingleFolderAsync();
 	if (storageFolder != null)
 	{
-		var storageFile1 = await storageFolder.CreateFileAsync("file1.txt");
-		var storageFile2 = await storageFolder.CreateFileAsync("file2.txt");
+		var storageFile1 = await storageFolder.CreateFileAsync("file1.txt", CreationCollisionOption.ReplaceExisting);
+		var storageFile2 = await storageFolder.CreateFileAsync("file2.txt", CreationCollisionOption.ReplaceExisting);
 
 		using (var stream = await storageFile1.OpenStreamForWriteAsync())
 		{

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/FileFolderPickerSamplePage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
@@ -158,8 +159,8 @@ namespace Uno.Gallery.Views.Samples
 			var storageFolder = await folderPicker.PickSingleFolderAsync();
 			if (storageFolder != null)
 			{
-				var storageFile1 = await storageFolder.CreateFileAsync("file1.txt");
-				var storageFile2 = await storageFolder.CreateFileAsync("file2.txt");
+				var storageFile1 = await storageFolder.CreateFileAsync("file1.txt", CreationCollisionOption.ReplaceExisting);
+				var storageFile2 = await storageFolder.CreateFileAsync("file2.txt", CreationCollisionOption.ReplaceExisting);
 
 				var textBox1 = ((sender as Button).Parent as StackPanel)
 					.FindName("ContentTextBox1") as TextBox;


### PR DESCRIPTION
`PickSaveMultipleFiles` now overwrites the `file1.txt` and `file2.txt` if they exist instead of crashing the app.

Fixes https://github.com/unoplatform/uno/issues/10219

GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10219

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

 -->

## What is the current behavior?

App crashes when selecting a folder that already has `file1.txt` or `file2.txt` in the `PickSaveMultipleFiles` example.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Instead of crashing, the app overwrites the existing files.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
