### PR TITLE
fix(iOS): accelerometer sample page crash

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml
@@ -38,12 +38,14 @@ private void Accelerometer_Shaken(Accelerometer sender, AccelerometerShakenEvent
 	++ShakeCount;
 }
 
-private void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
+private async void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
 {
-	LastReadTimestamp = args.Reading.Timestamp;
-	AccelerationX = args.Reading.AccelerationX;
-	AccelerationY = args.Reading.AccelerationY;
-	AccelerationZ = args.Reading.AccelerationZ;
+	await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {
+		LastReadTimestamp = args.Reading.Timestamp;
+		AccelerationX = args.Reading.AccelerationX;
+		AccelerationY = args.Reading.AccelerationY;
+		AccelerationZ = args.Reading.AccelerationZ;
+	});
 }
 -->
 								

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel;
+using Windows.ApplicationModel.Core;
 using Windows.Devices.Sensors;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -173,12 +175,14 @@ namespace Uno.Gallery.Views.Samples
 			++ShakeCount;
 		}
 
-		private void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
+		private async void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
 		{
-			LastReadTimestamp = args.Reading.Timestamp;
-			AccelerationX = args.Reading.AccelerationX;
-			AccelerationY = args.Reading.AccelerationY;
-			AccelerationZ = args.Reading.AccelerationZ;
+			await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {
+				LastReadTimestamp = args.Reading.Timestamp;
+				AccelerationX = args.Reading.AccelerationX;
+				AccelerationY = args.Reading.AccelerationY;
+				AccelerationZ = args.Reading.AccelerationZ;
+			});
 		}
 	}
 }

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AccelerometerSamplePage.xaml.cs
@@ -177,7 +177,7 @@ namespace Uno.Gallery.Views.Samples
 
 		private async void Accelerometer_ReadingChanged(Accelerometer sender, AccelerometerReadingChangedEventArgs args)
 		{
-			await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {
+			_ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {
 				LastReadTimestamp = args.Reading.Timestamp;
 				AccelerationX = args.Reading.AccelerationX;
 				AccelerationY = args.Reading.AccelerationY;


### PR DESCRIPTION
GitHub Issue (If applicable): 

closes https://github.com/unoplatform/uno/issues/10217


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The 
Accelerometer sample (page) crashes when reading the values.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
