### PR TITLE
Restore net6 targets for mobile

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos</TargetFrameworks>
 		<SingleProject>true</SingleProject>
 		<OutputType>Exe</OutputType>
-		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net7.0-ios'">iossimulator-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net7.0-macos'">osx-x64</RuntimeIdentifier>
-		<InvariantGlobalization Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">true</InvariantGlobalization>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-macos'">osx-x64</RuntimeIdentifier>
+		<InvariantGlobalization Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">true</InvariantGlobalization>
 		<!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
-		<!-- <MtouchExtraArgs Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
+		<!-- <MtouchExtraArgs Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
 		<!-- Required for C# Hot Reload -->
 		
 		<!-- https://github.com/dotnet/runtime/issues/68808 -->
 		<!--<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>-->
 		<IsUnoHead>true</IsUnoHead>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net7.0-macos'">10.14</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net6.0-macos'">10.14</SupportedOSPlatformVersion>
 		<NoWarn>CA1416;Uno0001</NoWarn>
 	</PropertyGroup>
 	
@@ -60,7 +60,7 @@
 	</ItemGroup>
 	
 	<Choose>
-		<When Condition="'$(TargetFramework)'=='net7.0-android'">
+		<When Condition="'$(TargetFramework)'=='net6.0-android'">
 			<PropertyGroup Condition="'$(Configuration)'=='Release' and '$(System_PullRequest_IsFork)'!='True'">
 				<AndroidKeyStore>true</AndroidKeyStore>
 				<AndroidSigningKeyStore>..\Gallery.Droid\calc-prod.keystore</AndroidSigningKeyStore>
@@ -83,7 +83,7 @@
 				<RunAOTCompilation>true</RunAOTCompilation>
 			</PropertyGroup>
 		</When>
-		<When Condition="'$(TargetFramework)'=='net7.0-ios'">
+		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 			</ItemGroup>
@@ -100,7 +100,7 @@
 				<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 			</PropertyGroup>
 		</When>
-		<When Condition="'$(TargetFramework)'=='net7.0-maccatalyst'">
+		<When Condition="'$(TargetFramework)'=='net6.0-maccatalyst'">
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 			</ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,17 +159,17 @@ jobs:
 
   - template: build/stage-build-ios-xamarin.yml
 
-- job: macOS_net7
+- job: macOS_netcore
   strategy:
     maxParallel: 2
     matrix:
       iOS:
-        BuildTargetFramework: net7.0-ios
+        BuildTargetFramework: net6.0-ios
         ArtifactName: iOS-mobile
         ApplicationBuildNumberOffset: 50
         BuildCommand: publish
       Catalyst:
-        BuildTargetFramework: net7.0-maccatalyst
+        BuildTargetFramework: net6.0-maccatalyst
         ArtifactName: Catalyst
         ApplicationBuildNumberOffset: 50
         BuildCommand: build

--- a/build/stage-build-android-mobile.yml
+++ b/build/stage-build-android-mobile.yml
@@ -19,21 +19,21 @@ steps:
 
 - script: |
     cd $(build.sourcesdirectory)/Uno.Gallery/Uno.Gallery.Mobile
-    dotnet publish -f:net7.0-android -c:Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:AndroidSigningKeyStore=$(keyStore.secureFilePath) /p:AndroidSigningStorePass=$(AndroidSigningStorePass) /p:AndroidSigningKeyPass=$(AndroidSigningKeyPass) /p:AndroidSigningKeyAlias=$(AndroidSigningKeyAlias) /p:AndroidKeyStore=true /bl:$(build.artifactstagingdirectory)/build-$(BuildForPlayStore).binlog 
-  displayName: 'Build Android Package (net7)'
+    dotnet publish -f:net6.0-android -c:Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:AndroidSigningKeyStore=$(keyStore.secureFilePath) /p:AndroidSigningStorePass=$(AndroidSigningStorePass) /p:AndroidSigningKeyPass=$(AndroidSigningKeyPass) /p:AndroidSigningKeyAlias=$(AndroidSigningKeyAlias) /p:AndroidKeyStore=true /bl:$(build.artifactstagingdirectory)/build-$(BuildForPlayStore).binlog 
+  displayName: 'Build Android Package (net6)'
   condition: eq(variables['System.PullRequest.IsFork'],'False')
 
 - script: |
     cd $(build.sourcesdirectory)/Uno.Gallery/Uno.Gallery.Mobile
-    dotnet publish -f:net7.0-android -c:Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:AndroidKeyStore=False /bl:$(build.artifactstagingdirectory)/build-$(BuildForPlayStore).binlog 
-  displayName: 'Build Android Package (Fork - net7)'
+    dotnet publish -f:net6.0-android -c:Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:AndroidKeyStore=False /bl:$(build.artifactstagingdirectory)/build-$(BuildForPlayStore).binlog 
+  displayName: 'Build Android Package (Fork - net6)'
   condition: eq(variables['System.PullRequest.IsFork'],'True')
 
 - task: CopyFiles@2
-  displayName: 'Publish Android net7 Binaries'
+  displayName: 'Publish Android net6 Binaries'
   retryCountOnTaskFailure: 3
   inputs:
-    SourceFolder: $(build.sourcesdirectory)/Uno.Gallery/Uno.Gallery.Mobile/bin/Release/net7.0-android
+    SourceFolder: $(build.sourcesdirectory)/Uno.Gallery/Uno.Gallery.Mobile/bin/Release/net6.0-android
     Contents: |
       **/*.aab
       **/*.apk

--- a/build/templates/dotnet-install-mac.yml
+++ b/build/templates/dotnet-install-mac.yml
@@ -1,7 +1,7 @@
 parameters:
-  DotNetVersion: '7.0.102'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  DotNetVersion: '6.0.300'
+  UnoCheck_Version: '1.5.0-dev.9'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/57a1ec121506a4e96baf5327135b4b1ca464634f/manifests/uno.ui-preview.manifest.json'
   Dotnet_Root: '/usr/local/share/dotnet/'
   Dotnet_Tools: '~/.dotnet/tools'
 

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,7 +1,7 @@
 parameters:
-  DotNetVersion: '7.0.102'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  DotNetVersion: '6.0.300'
+  UnoCheck_Version: '1.5.0-dev.9'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/57a1ec121506a4e96baf5327135b4b1ca464634f/manifests/uno.ui-preview.manifest.json'
 
 steps:
 


### PR DESCRIPTION
Partially reverts unoplatform/Uno.Gallery#623 for mobile targets, caused by https://github.com/unoplatform/uno/issues/11044