### PR TITLE
fix: Removed Lamp from unsupported platforms

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/LampSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/LampSamplePage.xaml
@@ -1,14 +1,11 @@
-﻿<Page
-	x:Class="Uno.Gallery.Views.Samples.LampSamplePage"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="using:Uno.Gallery"
-	xmlns:samples="using:Uno.Gallery.Views.Samples"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-	xmlns:smtx="using:ShowMeTheXAML"
-	mc:Ignorable="d">
+﻿<Page x:Class="Uno.Gallery.Views.Samples.LampSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  xmlns:local="using:Uno.Gallery"
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
@@ -18,7 +15,7 @@
 						<smtx:XamlDisplay UniqueKey="LampSamplePage_Sample"
 										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel"
 										  smtx:XamlDisplayExtensions.Header="Lamp control">
-							<StackPanel Spacing="20">
+							<StackPanel>
 								<!-- C# code
 if (await Lamp.GetDefaultAsync() is Lamp lamp)
 {
@@ -32,16 +29,22 @@ if (await Lamp.GetDefaultAsync() is Lamp lamp)
 }
 -->
 
-								<StackPanel.DataContext>
-									<samples:LampSamplePageViewModel />
-								</StackPanel.DataContext>
+								<Slider Header="Brightness"
+										Visibility="{Binding Data.IsBrightnessSupported, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+										Maximum="1"
+										Minimum="0"
+										Value="{Binding Data.BrightnessLevel, Mode=TwoWay}"
+										StepFrequency="0.1"
+										TickFrequency="0.1"
+										TickPlacement="Outside"
+										IsThumbToolTipEnabled="True"
+										Margin="0,0,0,20" />
 
-								<Slider Header="Brightness" Visibility="{Binding IsBrightnessSupported, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}" Maximum="1"
-										Minimum="0" Value="{Binding BrightnessLevel, Mode=TwoWay}" StepFrequency="0.1"
-										TickFrequency="0.1" TickPlacement="Outside" IsThumbToolTipEnabled="True" />
-
-								<Button Click="ChangeLampState_Click" IsEnabled="{Binding IsAvailable}">
-									<TextBlock Text="{Binding ButtonContent}" VerticalAlignment="Stretch" TextAlignment="Center" />
+								<Button Click="ChangeLampState_Click"
+										IsEnabled="{Binding Data.IsAvailable}">
+									<TextBlock Text="{Binding Data.ButtonContent}"
+											   VerticalAlignment="Stretch"
+											   TextAlignment="Center" />
 								</Button>
 							</StackPanel>
 						</smtx:XamlDisplay>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/LampSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/LampSamplePage.xaml.cs
@@ -7,7 +7,10 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
-	[SamplePage(SampleCategory.NonUIFeatures, "Lamp", Description = "Represents a lamp device. Allows you to turn the phone's camera flashlight on and off.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/Windows.Devices.Lights.Lamp")]
+	[SamplePage(SampleCategory.NonUIFeatures, "Lamp", Description = "Represents a lamp device. Allows you to turn the phone's camera flashlight on and off.", DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/Windows.Devices.Lights.Lamp", DataType = typeof(LampSamplePageViewModel))]
+#if !WINDOWS_UWP && !IS_WINUI && !__ANDROID__ && !__IOS__
+	[SampleConditional(SampleConditionals.Always, Reason = "API is not supported")]
+#endif
 	public sealed partial class LampSamplePage : Page
 	{
 		public LampSamplePage()
@@ -86,7 +89,7 @@ IsBrightnessSupported = true;
 			});
 		}
 
-		public async void Enable()
+		public void Enable()
 		{
 			if (_lamp != null)
 			{


### PR DESCRIPTION
Plus made some minor changes to the code of the sample.

GitHub Issue (If applicable): #665

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?
The Lamp sample always shows as not supported on WASM. The reason for it is because the API is not implemented on WASM.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
The Lamp sample is hidden from the platforms that does not support the API.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)