### PR TITLE
ci: continue-on-error with static-web-apps-deploy

### DIFF
--- a/.github/workflows/azure-static-webapp.yml
+++ b/.github/workflows/azure-static-webapp.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Publish to Azure Static WebApps
         id: builddeploy_uno
+        continue-on-error: true
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_STAGING }}


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
Azure Static WebApps failing the pr checks with:
> Reason: This Static Web App already has the maximum number of staging environments (10). Please remove one and try again.

## What is the new behavior?
Failure to deploy no longer blocks the PR.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)