### PR TITLE
fix: Different backgrounds across samples

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarDatePickerSamplePage.xaml
@@ -5,8 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
-	  xmlns:smtx="using:ShowMeTheXAML"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  xmlns:smtx="using:ShowMeTheXAML">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CalendarViewSamplePage.xaml
@@ -5,8 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  mc:Ignorable="d"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CardSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CardSamplePage.xaml
@@ -6,8 +6,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:smtx="using:ShowMeTheXAML"
-	  mc:Ignorable="d"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CommandBarSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/CommandBarSamplePage.xaml
@@ -4,8 +4,7 @@
 	  xmlns:local="using:Uno.Gallery"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout x:Name="SamplePageLayout">

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GridViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/GridViewSamplePage.xaml
@@ -9,7 +9,7 @@
 	  xmlns:converters="using:Uno.Gallery.Converters"
 	  mc:Ignorable="d xamarin">
 
-	<Grid>
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 
 			<local:SamplePageLayout.FluentTemplate>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/SwipeControlSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/SwipeControlSamplePage.xaml
@@ -10,7 +10,7 @@
 
 	<!-- Samples adapted from Microsoft XAML Controls Gallery: -->
 	<!-- https://github.com/microsoft/Xaml-Controls-Gallery -->
-	<Grid Background="{ThemeResource BackgroundBrush}">
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 			<local:SamplePageLayout.FluentTemplate>
 				<DataTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): #710

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?
Some pages use different backgrounds and it makes the samples inconsistent in Canary builds. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)
