### PR TITLE
fix: Hide Acrylic sample on Skia

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AcrylicSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AcrylicSamplePage.xaml.cs
@@ -1,24 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+﻿using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
 
 	[SamplePage(SampleCategory.UIFeatures, "Acrylic", Description = "AcrylicBrush is a translucent brush that can be used as background.", DocumentationLink = "https://docs.microsoft.com/en-us/windows/uwp/design/style/acrylic")]
+
+#if HAS_UNO_SKIA
+	[SampleConditional(SampleConditionals.Disabled, Reason = "Acrylic is not supported")]
+#endif
 	public sealed partial class AcrylicSamplePage : Page
 	{
 		public AcrylicSamplePage()

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AcrylicSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/AcrylicSamplePage.xaml.cs
@@ -4,10 +4,7 @@ namespace Uno.Gallery.Views.Samples
 {
 
 	[SamplePage(SampleCategory.UIFeatures, "Acrylic", Description = "AcrylicBrush is a translucent brush that can be used as background.", DocumentationLink = "https://docs.microsoft.com/en-us/windows/uwp/design/style/acrylic")]
-
-#if HAS_UNO_SKIA
-	[SampleConditional(SampleConditionals.Disabled, Reason = "Acrylic is not supported")]
-#endif
+	[SampleConditional(SampleConditionals.Always ^ SampleConditionals.SkiaGtk, Reason = "Acrylic is not supported")]
 	public sealed partial class AcrylicSamplePage : Page
 	{
 		public AcrylicSamplePage()


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10828#issuecomment-1428471596

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Acrylic sample is hidden on Skia.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)