### PR TITLE
fix(sample): SampleConditionals.Always includes Disabled

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Entities/SampleConditionals.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Entities/SampleConditionals.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Uno.Gallery
 {
 	[Flags]
-	public enum SampleConditionals
+	public enum SampleConditionals : uint
 	{
 		Windows = 1 << 0,
 		Wasm = 1 << 1,
@@ -18,7 +18,7 @@ namespace Uno.Gallery
 		Mobile = Droid | iOS,
 		SkiaBased = Wasm | SkiaGtk,
 		
-		Disabled = 1 << 31,
-		Always = int.MaxValue ^ Disabled,
+		Disabled = 1U << 31,
+		Always = uint.MaxValue ^ Disabled,
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`SampleConditionals.Always.HasFlag(SampleConditionals.Disabled)` is `true`.


## What is the new behavior?
`SampleConditionals.Always.HasFlag(SampleConditionals.Disabled)` will be `false`.

## Other information
`int.MaxValue` doesnt set the bit on where `1 << 31` is on. And then, xor'ing it just set it...