### PR TITLE
fix: infobadge opacity slider

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBadgeSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/InfoBadgeSamplePage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Gallery.ViewModels;
+﻿using System;
+using Uno.Gallery.ViewModels;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -29,7 +30,7 @@ namespace Uno.Gallery.Views.Samples
 				BadgeStyle = Application.Current.Resources["InfoBadgeStyle_" + SelectedStyle] as Style;
 			}
 		}
-		public double Opacity { get => GetProperty<double>(); set => SetProperty(value); }
+		public double Opacity { get => GetProperty<double>(); set => SetProperty(Math.Round(value, 1)); }
 		public Style BadgeStyle { get => GetProperty<Style>(); set => SetProperty(value); }
 
 		public InfoBadgeSamplePageViewModel()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12402

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Opacity slider displays numeric values for 0.6 and more.
  - Added rounding function to setter.

![opacity_slider](https://github.com/unoplatform/Uno.Gallery/assets/70542961/e9841c4e-9224-4a1f-b63a-0ceb1c50d37a)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

