### PR TITLE
[Gallery][Android] MediaPlayerElement the Audio of the played video keeps on running for the first and third 'show sample' option.

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage1.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage1.xaml.cs
@@ -13,7 +13,11 @@ namespace Uno.Gallery.Views.NestedPages
 			Unloaded += MediaPlayerElementSample_NestedPage1_Unloaded;
 		}
 
-		private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			MediaPlayerElementSample1.MediaPlayer.Pause();
+			Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		}
 
 		private void MediaPlayerElementSample_NestedPage1_Unloaded(object sender, RoutedEventArgs e)
 		{

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage2.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage2.xaml.cs
@@ -11,8 +11,11 @@ namespace Uno.Gallery.Views.NestedPages
 			Unloaded += MediaPlayerElementSample_NestedPage2_Unloaded;
         }
 
-        private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
-
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			MediaPlayerElementSample2.MediaPlayer.Pause();
+			Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		}
 		private void MediaPlayerElementSample_NestedPage2_Unloaded(object sender, RoutedEventArgs e)
 		{
 			MediaPlayerElementSample2.MediaPlayer.Pause();

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage3.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage3.xaml.cs
@@ -11,7 +11,11 @@ namespace Uno.Gallery.Views.NestedPages
 			Unloaded += MediaPlayerElementSample_NestedPage3_Unloaded;
         }
 
-        private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			MediaPlayerElementSample3.MediaPlayer.Pause();
+			Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		}
 
 		private void MediaPlayerElementSample_NestedPage3_Unloaded(object sender, RoutedEventArgs e)
 		{

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage4.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage4.xaml.cs
@@ -11,7 +11,11 @@ namespace Uno.Gallery.Views.NestedPages
 			Unloaded += MediaPlayerElementSample_NestedPage4_Unloaded;
         }
 
-        private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			MediaPlayerElementSample4.MediaPlayer.Pause();
+			Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		}
 
 		private void MediaPlayerElementSample_NestedPage4_Unloaded(object sender, RoutedEventArgs e)
 		{

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
@@ -28,7 +28,12 @@ namespace Uno.Gallery.Views.NestedPages
 			MediaPlayerElementSample5.MediaPlayer.Source = mediaPlaybackList;
 		}
 
-		private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
+
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			MediaPlayerElementSample5.MediaPlayer.Pause();
+			Shell.GetForCurrentView().BackNavigateFromNestedSample();
+		}
 
 		private void MediaPlayerElementSample_NestedPage5_Unloaded(object sender, RoutedEventArgs e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable):

https://github.com/unoplatform/uno/issues/12638

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In the current version the video continues to play when changing samples.

Note:- The sound of the video is not working.
Current behaviour is the Audio of the played video keep on playing even close all the options.
To close the music need to kill Gallery app and relaunch it.

## What is the new behavior?

Now the video stop to play when change the samples.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
