### PR TITLE
[Gallery][Wasm] MediaPlayerElement, [X] Close button does not work for customizable option once click on the last sample option.

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
@@ -23,10 +23,12 @@ namespace Uno.Gallery.Views.NestedPages
 			
 			if (ApiInformation.IsPropertyPresent("Windows.Media.Playback.MediaPlaybackList", "Items"))
 			{
+#pragma warning disable Uno0001 // Uno type or member is not implemented
 				var mediaPlaybackList = new MediaPlaybackList();
 				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"))));
 				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/audio/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp3"))));
 				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"))));
+#pragma warning restore Uno0001 // Uno type or member is not implemented
 
 				MediaPlayerElementSample5.MediaPlayer.Source = mediaPlaybackList;
 			}

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MediaPlayerLocal = Windows.Media.Playback.MediaPlayer;
+using System;
 using System.Collections.Generic;
 using Windows.Foundation.Metadata;
 using Windows.Media.Core;
@@ -36,7 +37,7 @@ namespace Uno.Gallery.Views.NestedPages
 			{
 				if (MediaPlayerElementSample5.MediaPlayer == null)
 				{
-					MediaPlayerElementSample5.SetMediaPlayer(new Windows.Media.Playback.MediaPlayer());
+					MediaPlayerElementSample5.SetMediaPlayer(new MediaPlayerLocal());
 				}
 				MediaPlayerElementSample5.Source = MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"));
 			}

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MediaPlayerElementSample_NestedPage5.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Windows.Foundation.Metadata;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Microsoft.UI.Xaml;
@@ -19,15 +20,25 @@ namespace Uno.Gallery.Views.NestedPages
 
 		private void InitializePlaybackList()
 		{
-			var mediaPlaybackList = new MediaPlaybackList();
+			
+			if (ApiInformation.IsPropertyPresent("Windows.Media.Playback.MediaPlaybackList", "Items"))
+			{
+				var mediaPlaybackList = new MediaPlaybackList();
+				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"))));
+				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/audio/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp3"))));
+				mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"))));
 
-			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"))));
-			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/audio/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp3"))));
-			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"))));
-
-			MediaPlayerElementSample5.MediaPlayer.Source = mediaPlaybackList;
+				MediaPlayerElementSample5.MediaPlayer.Source = mediaPlaybackList;
+			}
+			else
+			{
+				if (MediaPlayerElementSample5.MediaPlayer == null)
+				{
+					MediaPlayerElementSample5.SetMediaPlayer(new Windows.Media.Playback.MediaPlayer());
+				}
+				MediaPlayerElementSample5.Source = MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"));
+			}
 		}
-
 
 		private void NavigateBack(object sender, RoutedEventArgs e)
 		{

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml
@@ -8,7 +8,7 @@
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<local:SamplePageLayout>
+		<local:SamplePageLayout x:Name="LocalSamplePageLayout">
 			<local:SamplePageLayout.FluentTemplate>
 				<DataTemplate>
 					<StackPanel>
@@ -40,10 +40,12 @@
 								Click="LaunchMediaPlayerElementSample4"
 								Style="{StaticResource FilledButtonStyle}" />
 
-						<TextBlock Text="MediaPlayerElement sample using a Playlist"
-								   Style="{StaticResource TitleLarge}"
-								   Margin="0,16" />
-						<Button Content="Show sample"
+						<TextBlock Name="LaunchMediaPlayerElementSampleTextBlock5"
+								Text="MediaPlayerElement sample using a Playlist"
+								Style="{StaticResource TitleLarge}"
+								Margin="0,16" />
+						<Button Name="LaunchMediaPlayerElementSampleButton5"
+								Content="Show sample"
 								Click="LaunchMediaPlayerElementSample5"
 								Style="{StaticResource FilledButtonStyle}" />
 					</StackPanel>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
@@ -2,7 +2,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml;
 using Windows.Foundation.Metadata;
-using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -15,7 +14,7 @@ namespace Uno.Gallery.Views.Samples
 			Loaded += MediaPlayerElementSamplePage_Loaded;
 		}
 
-		private void MediaPlayerElementSamplePage_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		private void MediaPlayerElementSamplePage_Loaded(object sender, RoutedEventArgs e)
 		{
 			if (!ApiInformation.IsPropertyPresent("Windows.Media.Playback.MediaPlaybackList", "Items"))
 			{
@@ -23,8 +22,8 @@ namespace Uno.Gallery.Views.Samples
 				TextBlock textBlockSampleButton5 = (TextBlock)LocalSamplePageLayout.FindName("LaunchMediaPlayerElementSampleTextBlock5");
 				if (buttonSampleButton5 != null && textBlockSampleButton5 != null)
 				{
-					buttonSampleButton5.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-					textBlockSampleButton5.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+					buttonSampleButton5.Visibility = Visibility.Collapsed;
+					textBlockSampleButton5.Visibility = Visibility.Collapsed;
 				}
 			}
 

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using Uno.Gallery.Views.NestedPages;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml.Controls;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -10,6 +12,22 @@ namespace Uno.Gallery.Views.Samples
 		public MediaPlayerElementSamplePage()
 		{
 			this.InitializeComponent();
+			Loaded += MediaPlayerElementSamplePage_Loaded;
+		}
+
+		private void MediaPlayerElementSamplePage_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			if (!ApiInformation.IsPropertyPresent("Windows.Media.Playback.MediaPlaybackList", "Items"))
+			{
+				Button buttonSampleButton5 = (Button)LocalSamplePageLayout.FindName("LaunchMediaPlayerElementSampleButton5");
+				TextBlock textBlockSampleButton5 = (TextBlock)LocalSamplePageLayout.FindName("LaunchMediaPlayerElementSampleTextBlock5");
+				if (buttonSampleButton5 != null && textBlockSampleButton5 != null)
+				{
+					buttonSampleButton5.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+					textBlockSampleButton5.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+				}
+			}
+
 		}
 
 		private void LaunchMediaPlayerElementSample1(object sender, RoutedEventArgs e)

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/MediaPlayerElementSamplePage.xaml.cs
@@ -14,7 +14,7 @@ namespace Uno.Gallery.Views.Samples
 			Loaded += MediaPlayerElementSamplePage_Loaded;
 		}
 
-		private void MediaPlayerElementSamplePage_Loaded(object sender, RoutedEventArgs e)
+		private void MediaPlayerElementSamplePage_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
 		{
 			if (!ApiInformation.IsPropertyPresent("Windows.Media.Playback.MediaPlaybackList", "Items"))
 			{

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -35,6 +35,9 @@
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="Uno.WinUI.Svg" Version="5.0.0-dev.1728" />
+		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.18" />
+		<PackageReference Include="Uno.WinUI.MediaPlayer.Skia.Gtk" Version="5.0.0-dev.1148" />
+
 	</ItemGroup>
 
 	<Import Project="..\Uno.Gallery.Shared\Uno.Gallery.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

https://github.com/unoplatform/uno/issues/12653

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When click close button, mediaplayer window for Customizable option should get close.

## What is the new behavior?

When click close button, after try to enter on the MPE sample playlist, and enter in other sample mediaplayer window, as Customizable option, the window should get close.

Feature items/playlist is just implemented for ANDROID || IOS || MACOS
So in the Sample 5 (Playlist) we just show the first video.
And as requested we disable the feature on unsupported platform, so the Sample 5, playlist, do not show on other platforms.

![image](https://github.com/unoplatform/Uno.Gallery/assets/116665025/fc853196-65a0-467d-b1bc-b13ece9d437c)

And i added the references to test the MediaPlayer Skia on windows

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)



## Other information


Internal Issue (If applicable):