### PR TITLE
fix: Use MUXC TwoPaneView

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TwoPaneViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TwoPaneViewSamplePage.xaml
@@ -4,67 +4,68 @@
 	  xmlns:local="using:Uno.Gallery"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
-			<local:SamplePageLayout.FluentTemplate>
+			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>
 					<StackPanel>
 
-						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_Fluent_Default"
-										  smtx:XamlDisplayExtensions.Header="Sample with standard size adjustment">
-							<TwoPaneView Pane2Length="*">
-								<TwoPaneView.Pane1>
+						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_Default"
+										  smtx:XamlDisplayExtensions.Header="TwoPaneView with standard size adjustment">
+							<muxc:TwoPaneView Pane2Length="*">
+								<muxc:TwoPaneView.Pane1>
 									<Border Background="{StaticResource SampleSecondBackgroundBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 1</TextBlock>
 									</Border>
-								</TwoPaneView.Pane1>
+								</muxc:TwoPaneView.Pane1>
 
-								<TwoPaneView.Pane2>
+								<muxc:TwoPaneView.Pane2>
 									<Border Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 2</TextBlock>
 									</Border>
-								</TwoPaneView.Pane2>
-							</TwoPaneView>
+								</muxc:TwoPaneView.Pane2>
+							</muxc:TwoPaneView>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_Fluent_RelativeSizing"
-										  smtx:XamlDisplayExtensions.Header="Sample with relative sizing">
-							<TwoPaneView Pane1Length="2*"
+						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_RelativeSizing"
+										  smtx:XamlDisplayExtensions.Header="TwoPaneView with relative sizing">
+							<muxc:TwoPaneView Pane1Length="2*"
 										 Pane2Length="*">
-								<TwoPaneView.Pane1>
+								<muxc:TwoPaneView.Pane1>
 									<Border Background="{StaticResource SampleSecondBackgroundBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 1</TextBlock>
 									</Border>
-								</TwoPaneView.Pane1>
+								</muxc:TwoPaneView.Pane1>
 
-								<TwoPaneView.Pane2>
+								<muxc:TwoPaneView.Pane2>
 									<Border Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 2</TextBlock>
 									</Border>
-								</TwoPaneView.Pane2>
-							</TwoPaneView>
+								</muxc:TwoPaneView.Pane2>
+							</muxc:TwoPaneView>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_Fluent_Width"
-										  smtx:XamlDisplayExtensions.Header="Sample with fixed width">
-							<TwoPaneView Pane1Length="200"
+						<smtx:XamlDisplay UniqueKey="TwoPaneViewSamplePage_Width"
+										  smtx:XamlDisplayExtensions.Header="TwoPaneView with fixed width">
+							<muxc:TwoPaneView Pane1Length="200"
 										 Background="{StaticResource SampleSecondBackgroundBrush}">
-								<TwoPaneView.Pane1>
+								<muxc:TwoPaneView.Pane1>
 									<Image Source="ms-appx:///Assets/ImageSample.png" />
-								</TwoPaneView.Pane1>
+								</muxc:TwoPaneView.Pane1>
 
-								<TwoPaneView.Pane2>
+								<muxc:TwoPaneView.Pane2>
 									<TextBlock TextWrapping="Wrap" Padding="15" FontSize="18">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</TextBlock>
-								</TwoPaneView.Pane2>
-							</TwoPaneView>
+								</muxc:TwoPaneView.Pane2>
+							</muxc:TwoPaneView>
 						</smtx:XamlDisplay>
 
 					</StackPanel>
 				</DataTemplate>
-			</local:SamplePageLayout.FluentTemplate>
+			</local:SamplePageLayout.DesignAgnosticTemplate>
 		</local:SamplePageLayout>
 	</Grid>
 </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TwoPaneViewSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TwoPaneViewSamplePage.xaml.cs
@@ -2,7 +2,9 @@
 
 namespace Uno.Gallery.Views.Samples
 {
-	[SamplePage(SampleCategory.UIComponents, "TwoPaneView", Description = "Represents a container with two views that size and position content in the available space, either side-by-side or top-bottom.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.twopaneview?view=winui-2.3")]
+	[SamplePage(SampleCategory.UIComponents, "TwoPaneView",
+		Description = "Represents a container with two views that size and position content in the available space, either side-by-side or top-bottom.",
+		DocumentationLink = "https://learn.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.twopaneview?view=winui-2.3")]
 	public sealed partial class TwoPaneViewSamplePage : Page
 	{
 		public TwoPaneViewSamplePage()


### PR DESCRIPTION
GitHub Issue (If applicable): #753

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?
TwoPaneView from WUXC is used, which is not supported by Uno.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Switched to MUXC TwoPaneView.

![image](https://github.com/unoplatform/Uno.Gallery/assets/78549750/ce8c238e-50cc-4a8e-8ae8-f2114ff81d2e)

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
