### PR TITLE
chore: Remove Cupertino TextBlock

### DIFF
--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
@@ -10,17 +10,17 @@
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 
-			<local:SamplePageLayout.FluentTemplate>
+			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>
 					<StackPanel>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_Simple"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Simple"
 										  smtx:XamlDisplayExtensions.Header="Simple TextBlock">
 
 							<TextBlock Text="Text" />
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_Foreground"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Foreground"
 										  smtx:XamlDisplayExtensions.Header="Foreground">
 							<StackPanel>
 
@@ -35,7 +35,7 @@
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_FontStyle"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_FontStyle"
 										  smtx:XamlDisplayExtensions.Header="FontStyle">
 							<StackPanel>
 
@@ -47,7 +47,7 @@
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_FontWeight"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_FontWeight"
 										  smtx:XamlDisplayExtensions.Header="FontWeight">
 							<StackPanel>
 
@@ -68,7 +68,7 @@
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_FontFamily"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_FontFamily"
 										  smtx:XamlDisplayExtensions.Header="FontFamily">
 							<StackPanel>
 
@@ -82,7 +82,7 @@
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_FontSize"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_FontSize"
 										  smtx:XamlDisplayExtensions.Header="FontSize">
 							<StackPanel>
 
@@ -97,255 +97,136 @@
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_Inlines"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Inlines"
 										  smtx:XamlDisplayExtensions.Header="Inlines">
 
 							<TextBlock TextWrapping="Wrap">TextBlock supports inline tags including <Bold>Bold</Bold>, <Italic>Italic</Italic>, <Underline>Underline</Underline>, <Span Foreground="Red">Span</Span>, and <Hyperlink Foreground="#1079CD"
 																																																									 NavigateUri="https://platform.uno/">Hyperlink</Hyperlink>.</TextBlock>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_Trimming"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Trimming"
 										  smtx:XamlDisplayExtensions.Header="TextTrimming &amp; MaxLines">
-							
-							<TextBlock
-									   TextTrimming="CharacterEllipsis"
+
+							<TextBlock TextTrimming="CharacterEllipsis"
 									   TextWrapping="Wrap"
-									   MaxLines="2" >
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+									   MaxLines="2">
+								<TextBlock.Text>
+									Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+								</TextBlock.Text>
 							</TextBlock>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_TextAlignment"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_TextAlignment"
 										  smtx:XamlDisplayExtensions.Header="TextAlignment">
 							<StackPanel>
-								
-								<TextBlock
-										   Width="200"
+
+								<TextBlock Width="200"
 										   Margin="0,5"
 										   TextWrapping="Wrap"
 										   TextAlignment="Left"
 										   HorizontalAlignment="Left">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+									<TextBlock.Text>
+										Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+									</TextBlock.Text>
 								</TextBlock>
-								
-								<TextBlock
-										   Width="200"
+
+								<TextBlock Width="200"
 										   Margin="0,5"
 										   TextWrapping="Wrap"
 										   TextAlignment="Center"
 										   HorizontalAlignment="Center">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+									<TextBlock.Text>
+										Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+									</TextBlock.Text>
 								</TextBlock>
-								
-								<TextBlock
-										   Width="200"
+
+								<TextBlock Width="200"
 										   Margin="0,5"
 										   TextWrapping="Wrap"
 										   TextAlignment="Right"
 										   HorizontalAlignment="Right">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+									<TextBlock.Text>
+										Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+									</TextBlock.Text>
 								</TextBlock>
-								
-								<TextBlock
-										   Margin="0,5"
+
+								<TextBlock Margin="0,5"
 										   TextWrapping="Wrap"
 										   TextAlignment="Justify"
 										   HorizontalAlignment="Left">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+									<TextBlock.Text>
+										Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+									</TextBlock.Text>
 								</TextBlock>
 							</StackPanel>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_CharacterSpacing"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_CharacterSpacing"
 										  smtx:XamlDisplayExtensions.Header="CharacterSpacing">
-							
-							<TextBlock 
-									   TextWrapping="Wrap"
+
+							<TextBlock TextWrapping="Wrap"
 									   CharacterSpacing="100">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+								<TextBlock.Text>
+									Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+								</TextBlock.Text>
 							</TextBlock>
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_Fluent_LineHeight"
+						<smtx:XamlDisplay UniqueKey="TextBlockSamplePage_LineHeight"
 										  smtx:XamlDisplayExtensions.Header="LineHeight">
-							
-							<TextBlock 
-									   TextWrapping="Wrap"
+
+							<TextBlock TextWrapping="Wrap"
 									   LineHeight="30">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
+								<TextBlock.Text>
+									Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
 commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
 Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
 rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
 curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
 sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
 turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
+								</TextBlock.Text>
 							</TextBlock>
 						</smtx:XamlDisplay>
 					</StackPanel>
 				</DataTemplate>
-			</local:SamplePageLayout.FluentTemplate>
-			<local:SamplePageLayout.CupertinoTemplate>
-				<DataTemplate>
-					<StackPanel>
-
-						<!-- Large title -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_LargeTitle">
-							<TextBlock Text="Large title"
-									   Style="{StaticResource CupertinoLargeTitle}" />
-						</smtx:XamlDisplay>
-
-						<!-- Title 1 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_PrimaryTitle">
-							<TextBlock Text="Title 1"
-									   Style="{StaticResource CupertinoPrimaryTitle}" />
-						</smtx:XamlDisplay>
-
-						<!-- Title 2 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_SecondaryTitle">
-							<TextBlock Text="Title 2"
-									   Style="{StaticResource CupertinoSecondaryTitle}" />
-						</smtx:XamlDisplay>
-
-						<!-- Title 3 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_TertiaryTitle">
-							<TextBlock Text="Title 3"
-									   Style="{StaticResource CupertinoTertiaryTitle}" />
-						</smtx:XamlDisplay>
-
-						<!-- Headline -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Headline">
-							<TextBlock Text="Headline"
-									   Style="{StaticResource CupertinoHeadline}" />
-						</smtx:XamlDisplay>
-
-						<!-- Body -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Body"
-										  smtx:XamlDisplayExtensions.Header="Body">
-							<TextBlock  Style="{StaticResource CupertinoBody}">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
-commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
-Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
-rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
-curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
-sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
-turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
-							</TextBlock>
-						</smtx:XamlDisplay>
-
-						<!-- Callout -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Callout">
-							<TextBlock Text="Callout"
-									   Style="{StaticResource CupertinoCallout}" />
-						</smtx:XamlDisplay>
-
-						<!-- Subhead -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Subhead">
-							<TextBlock Text="Subhead"
-									   Style="{StaticResource CupertinoSubhead}" />
-						</smtx:XamlDisplay>
-
-						<!-- Footnote -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_Footnote"
-										  smtx:XamlDisplayExtensions.Header="Footnote">
-							<TextBlock Style="{StaticResource CupertinoFootnote}">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
-commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
-Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
-rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
-curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
-sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
-turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
-							</TextBlock>
-						</smtx:XamlDisplay>
-
-						<!-- Caption 1 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_PrimaryCaption"
-										  smtx:XamlDisplayExtensions.Header="Caption 1">
-							<TextBlock Style="{StaticResource CupertinoPrimaryCaption}">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
-commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
-Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
-rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
-curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
-sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
-turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
-						</TextBlock>
-						</smtx:XamlDisplay>
-
-						<!-- Caption 2 -->
-						<smtx:XamlDisplay UniqueKey="Cupertino_TextBlockSamplePage_SecondaryCaption"
-										  smtx:XamlDisplayExtensions.Header="Caption 2">
-							<TextBlock Style="{StaticResource CupertinoSecondaryCaption}">
-<TextBlock.Text>
-Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper 
-commodo primis ornare himenaeos, inceptos tellus accumsan praesent laoreet. 
-Pharetra semper ullamcorper neque mollis vestibulum luctus gravida facilisi 
-rhoncus, rutrum massa bibendum vitae imperdiet quisque fames dignissim, varius 
-curae erat risus platea orci quis scelerisque. Auctor erat vestibulum enim sodales 
-sapien nam litora rhoncus condimentum praesent, platea dui odio eros integer id gravida
-turpis semper nisi maecenas, nascetur dictumst sed arcu aenean varius dis leo habitant.
-</TextBlock.Text>
-							</TextBlock>
-						</smtx:XamlDisplay>
-					</StackPanel>
-				</DataTemplate>
-			</local:SamplePageLayout.CupertinoTemplate>
+			</local:SamplePageLayout.DesignAgnosticTemplate>
 		</local:SamplePageLayout>
 	</Grid>
 </Page>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml
@@ -8,7 +8,7 @@
 	  mc:Ignorable="d">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<local:SamplePageLayout>
+		<local:SamplePageLayout IsDesignAgnostic="True">
 
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.UWP/Views/SamplePages/TextBlockSamplePage.xaml.cs
@@ -2,7 +2,9 @@
 
 namespace Uno.Gallery.Views.Samples
 {
-	[SamplePage(SampleCategory.UIComponents, "TextBlock", Description = "This control is used to display text.", DocumentationLink = "https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textblock")]
+	[SamplePage(SampleCategory.UIComponents, "TextBlock",
+		Description = "A lightweight control for displaying text.",
+		DocumentationLink = "https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textblock")]
 	public sealed partial class TextBlockSamplePage : Page
 	{
 		public TextBlockSamplePage()


### PR DESCRIPTION
GitHub Issue (If applicable): #805

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

The TextBlock sample has a Cupertino style which showcases the same things as Typography page and doesn't make much sense.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Removed the Cupertino style from the sample and made it design agnostic.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->