### PR TITLE
fix: load proper design theme resources per tab

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.322" />
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 		<PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.322" />
+		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.325" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.WinUI" Version="5.0.0-dev.1728" />

--- a/Uno.Gallery/Uno.Gallery.Shared/App.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/App.xaml
@@ -21,7 +21,7 @@
 				<!-- Load WinUI resources -->
 				<!-- Load these resources after the Material/Cupertino resources. This ensures that the default Fluent styles will be used as the implicit styles. -->
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-				
+
 				<!-- Application's custom styles -->
 				<ResourceDictionary Source="Views/Colors.xaml" todo:note="define some colors\brushes, and images resources; not for color overriding" />
 				<ResourceDictionary Source="Views/Converters.xaml" />

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
@@ -218,7 +218,15 @@
 														  VerticalAlignment="Stretch"
 														  Content="{TemplateBinding Content}"
 														  ContentTemplate="{TemplateBinding MaterialTemplate}"
-														  Visibility="Collapsed" />
+														  Visibility="Collapsed">
+											<ContentPresenter.Resources>
+												<ResourceDictionary>
+													<ResourceDictionary.MergedDictionaries>
+														<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material" />
+													</ResourceDictionary.MergedDictionaries>
+												</ResourceDictionary>
+											</ContentPresenter.Resources>
+										</ContentPresenter>
 
 										<!-- Fluent Content -->
 										<ContentPresenter x:Name="FluentContentPresenter"

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -21,7 +21,7 @@
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.322" />
+		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.325" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Cupertino" Version="4.0.0-dev.58" />

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -105,7 +105,7 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.6" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0-dev.1" />
 		<PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.322" />
+		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.325" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Cupertino" Version="4.0.0-dev.58" />

--- a/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
+++ b/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="7.1.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.322" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.322" />
+		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.325" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0012" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0012" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Gallery/issues/831

Design systems may be using the same resource keys, this causes a problem given that the Gallery itself is using Uno.Material but we also need to be able to display Fluent components as well as Material components in the "sample area". The sample area should load the proper resources for whichever design system it is displaying rather than relying on the styles being initialized globally at the app level