### PR TITLE
ci: bump uno-check to 1.13.0

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -47,6 +47,11 @@
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 	</ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
+		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
+		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
+	</PropertyGroup>
 	
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net7.0-android'">
@@ -89,11 +94,6 @@
 			<PropertyGroup Condition="'$(Configuration)'=='Release' and '$(System_PullRequest_IsFork)'!='True'">
 				<CodesignKey>iPhone Distribution</CodesignKey>
 				<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
-			</PropertyGroup>
-			
-			<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
-				<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
-				<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
 			</PropertyGroup>
 
 			<ItemGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">

--- a/build/stage-uitests-android.yml
+++ b/build/stage-uitests-android.yml
@@ -14,8 +14,6 @@
     clean: true
 
   - template: templates/dotnet-install-mac.yml
-  - template: templates/dotnet-install-windows.yml
-
   - template: templates/canary-updater.yml
 
   - bash: |

--- a/build/stage-uitests-ios.yml
+++ b/build/stage-uitests-ios.yml
@@ -14,8 +14,7 @@
     clean: true
 
   - template: templates/dotnet-install-mac.yml
-  - template: templates/dotnet-install-windows.yml
-    
+
   - bash: /bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${XCODE_ROOT};sudo xcode-select --switch ${XCODE_ROOT}/Contents/Developer"
     displayName: Select Xcode
     

--- a/build/stage-uitests-ios.yml
+++ b/build/stage-uitests-ios.yml
@@ -4,10 +4,10 @@
   variables:
     CI_Build: true
     SourceLinkEnabled: false
-    XCODE_ROOT: '/Applications/Xcode_14.2.app'
+    XCODE_ROOT: '/Applications/Xcode_14.3.app'
 
   pool:
-    vmImage: 'macos-12'
+    vmImage: 'macos-13'
 
   steps:
   - checkout: self

--- a/build/templates/dotnet-install-mac.yml
+++ b/build/templates/dotnet-install-mac.yml
@@ -1,7 +1,7 @@
 parameters:
   DotNetVersion: '7.0.306'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  UnoCheck_Version: '1.13.0'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/c3b289d7bb16a2a2df7f7f7f848d76fe1e74036d/manifests/uno.ui.manifest.json'
 steps:
   # Required until .NET 6 installs properly using UseDotnet
   # using preview builds

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,7 +1,7 @@
 parameters:
   DotNetVersion: '7.0.306'
-  UnoCheck_Version: '1.11.0-dev.2'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  UnoCheck_Version: '1.13.0'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/c3b289d7bb16a2a2df7f7f7f848d76fe1e74036d/manifests/uno.ui.manifest.json'
 steps:
 
   # Required until .NET 6 installs properly on Windows using UseDotnet


### PR DESCRIPTION
Now that Toolkit supports Shadows, it requires newer workload versions as a result of skiasharp dependencies so we need to bump Gallery