### PR TITLE
fix: sign-package ps script after switch to WinUI for the Sample App

### DIFF
--- a/build/sign-package.ps1
+++ b/build/sign-package.ps1
@@ -11,7 +11,7 @@ dotnet tool install --tool-path . SignClient
 # Setup Variables we need to pass into the sign client tool
 $appSettings = "$currentDirectory\SignClient.json"
 
-$filesToSign = Get-ChildItem -Recurse $Env:ArtifactDirectory\* -Include *.msixbundle | Select-Object -ExpandProperty FullName
+$filesToSign = Get-ChildItem -Recurse $Env:ArtifactDirectory\* -Include *.msix | Select-Object -ExpandProperty FullName
 
 foreach ($fileToSign in $filesToSign) {
     Write-Host "Submitting $fileToSign for signing"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

Msix package for Windows is not properly signed


## What is the new behavior?

Msix package for Windows is properly signed

