### PR TITLE
fix: add missing toggle switch description in Overviewpage

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/GeneralPages/OverviewPage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/GeneralPages/OverviewPage.xaml
@@ -115,18 +115,40 @@
 					</local:OverviewSampleView>
 
 					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
-						<StackPanel Spacing="8">
+						<Grid ColumnSpacing="16" RowSpacing="8">
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<Grid.RowDefinitions>
+								<RowDefinition Height="auto" />
+								<RowDefinition Height="auto" />
+							</Grid.RowDefinitions>
+
+							<TextBlock Text="ToggleSwitch"
+									   Style="{StaticResource BodySmall}"
+									   VerticalAlignment="Center"/>
 
 							<ToggleSwitch Header="ToggleSwitch"
 										  IsOn="True"
-                                          MinWidth="200"
-										  Style="{StaticResource ToggleSwitchStyle}" />
+										  MinWidth="200"
+										  Style="{StaticResource ToggleSwitchStyle}"
+										  Grid.Column="1" />
+
+							<TextBlock Text="Disabled"
+									   Style="{StaticResource BodySmall}"
+									   VerticalAlignment="Center"
+									   Grid.Row="1" />
+
 							<ToggleSwitch Header="Disabled"
 										  IsEnabled="False"
-                                          MinWidth="200"
-										  Style="{StaticResource ToggleSwitchStyle}" />
-
-						</StackPanel>
+										  MinWidth="200"
+										  Style="{StaticResource ToggleSwitchStyle}"
+										  Grid.Column="1"
+										  Grid.Row="1"/>
+						</Grid>
 					</local:OverviewSampleView>
 
 				</StackPanel>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
[Closes #11428](https://github.com/unoplatform/uno/issues/11428)
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It doesnt have any text 
![image](https://github.com/unoplatform/Uno.Gallery/assets/90481654/f01c4f9b-f61e-4fae-b6e7-a4545d6d9018)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Add some text to describe the toggle swith like there is with the other controls

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on ~~UWP~~ Windows.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
I did not put the text to the right of the control, because on some platform, even if you remove the minimum Width, it still takes 200 points of space.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
What it looks like: 
![image](https://github.com/unoplatform/Uno.Gallery/assets/90481654/d474c32b-11e5-4b16-ba16-4ea83394c3ef)
Expected look from issue: 
![image](https://github.com/unoplatform/Uno.Gallery/assets/90481654/711ffa01-cb39-4ef7-903b-a85f19f7ed52)


