### PR TITLE
build: adjust legacy canary updater overrides

### DIFF
--- a/build/4x-overrides.json
+++ b/build/4x-overrides.json
@@ -1,7 +1,11 @@
 [
 	{
-	  "PackageId": "Uno.WinUI",
-	  "UpdatedVersion": "(,4.99.0-dev.999]"
+		"PackageId": "Uno.UI.Adapter",
+		"UpdatedVersion": "(,4.99.0-dev.999]"
+	},
+	{
+		"PackageId": "Uno.WinUI",
+		"UpdatedVersion": "(,4.99.0-dev.999]"
 	},
 	{
 	  "PackageId": "Uno.WinUI.Lottie",
@@ -17,6 +21,10 @@
 	},
 	{
 	  "PackageId": "Uno.WinUI.Foldable",
+	  "UpdatedVersion": "(,4.99.0-dev.999]"
+	},
+	{
+	  "PackageId": "Uno.WinUI.MediaPlayer.Skia.Gtk",
 	  "UpdatedVersion": "(,4.99.0-dev.999]"
 	},
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
Certain packages weren't pinned to 4.x, and are bumped to 5.x during canary update process...

## What is the new behavior?
They are now pinned.