### PR TITLE
fix: CheckBox, RadioButton and ToggleSwitch controls labels not matching like it should

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -28,10 +28,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200-dev.13.gef3f523648" />
-		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Cupertino.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.6.0-dev.2" />
 		<PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Material.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.WinUI" Version="5.0.0-dev.2319" />

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/GeneralPages/OverviewPage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/GeneralPages/OverviewPage.xaml
@@ -35,23 +35,24 @@
 							<Button Content="ELEVATED"
 									AutomationProperties.AutomationId="Material_ElevatedButton"
 									Style="{StaticResource ElevatedButtonStyle}" />
-                            <Button Content="FILLED"
-                                    AutomationProperties.AutomationId="Material_FilledButton"
-                                    Style="{StaticResource FilledButtonStyle}" />
-                            <Button Content="TONAL"
-                                    AutomationProperties.AutomationId="Material_FilledTonalButton"
-                                    Style="{StaticResource FilledTonalButtonStyle}" />
-                            <Button Content="OUTLINED"
-                                    AutomationProperties.AutomationId="Material_OutlinedButton"
-                                    Style="{StaticResource OutlinedButtonStyle}" />
-                            <Button Content="TEXT"
-                                    AutomationProperties.AutomationId="Material_TextButton"
-                                    Style="{StaticResource TextButtonStyle}" />
-							<Button AutomationProperties.AutomationId="Material_IconButton" Style="{StaticResource IconButtonStyle}">
-                                <SymbolIcon Symbol="Favorite" />
-                            </Button>
+							<Button Content="FILLED"
+									AutomationProperties.AutomationId="Material_FilledButton"
+									Style="{StaticResource FilledButtonStyle}" />
+							<Button Content="TONAL"
+									AutomationProperties.AutomationId="Material_FilledTonalButton"
+									Style="{StaticResource FilledTonalButtonStyle}" />
+							<Button Content="OUTLINED"
+									AutomationProperties.AutomationId="Material_OutlinedButton"
+									Style="{StaticResource OutlinedButtonStyle}" />
+							<Button Content="TEXT"
+									AutomationProperties.AutomationId="Material_TextButton"
+									Style="{StaticResource TextButtonStyle}" />
+							<Button AutomationProperties.AutomationId="Material_IconButton"
+									Style="{StaticResource IconButtonStyle}">
+								<SymbolIcon Symbol="Favorite" />
+							</Button>
 
-                        </StackPanel>
+						</StackPanel>
 					</local:OverviewSampleView>
 
 					<!-- TextBox -->
@@ -96,6 +97,10 @@
 									  IsChecked="{x:Null}"
 									  IsThreeState="True"
 									  Style="{StaticResource CheckBoxStyle}" />
+							<CheckBox Content="Disabled"
+									  IsChecked="True"
+									  IsEnabled="False"
+									  Style="{StaticResource CheckBoxStyle}" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -104,51 +109,37 @@
 					<local:OverviewSampleView SamplePageType="samples:RadioButtonSamplePage">
 						<StackPanel Spacing="8">
 
-							<RadioButton Content="Checked"
+							<RadioButton GroupName="Material_RadioButton"
+										 Content="Checked"
 										 IsChecked="True"
 										 Style="{StaticResource RadioButtonStyle}" />
-							<RadioButton Content="Unchecked"
-										 IsChecked="False"
+							<RadioButton GroupName="Material_RadioButton"
+										 Content="Unchecked"
+										 Style="{StaticResource RadioButtonStyle}" />
+							<RadioButton Content="Disabled"
+										 IsChecked="True"
+										 IsEnabled="False"
 										 Style="{StaticResource RadioButtonStyle}" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
 
+					<!-- ToggleSwitch -->
 					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
-						<Grid ColumnSpacing="16" RowSpacing="8">
-
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="auto" />
-								<ColumnDefinition Width="*" />
-							</Grid.ColumnDefinitions>
-
-							<Grid.RowDefinitions>
-								<RowDefinition Height="auto" />
-								<RowDefinition Height="auto" />
-							</Grid.RowDefinitions>
+						<StackPanel Spacing="8">
 
 							<TextBlock Text="ToggleSwitch"
-									   Style="{StaticResource BodySmall}"
-									   VerticalAlignment="Center"/>
+									   Foreground="{ThemeResource OnSurfaceVariantBrush}"
+									   Style="{StaticResource BodySmall}" />
+							<ToggleSwitch IsOn="True"
+										  Style="{StaticResource MaterialToggleSwitchStyle}" />
+							<TextBlock Text="ToggleSwitch Disabled"
+									   Foreground="{ThemeResource OnSurfaceLowBrush}"
+									   Style="{StaticResource BodySmall}" />
+							<ToggleSwitch IsEnabled="False"
+										  Style="{StaticResource MaterialToggleSwitchStyle}" />
 
-							<ToggleSwitch Header="ToggleSwitch"
-										  IsOn="True"
-										  MinWidth="200"
-										  Style="{StaticResource ToggleSwitchStyle}"
-										  Grid.Column="1" />
-
-							<TextBlock Text="Disabled"
-									   Style="{StaticResource BodySmall}"
-									   VerticalAlignment="Center"
-									   Grid.Row="1" />
-
-							<ToggleSwitch Header="Disabled"
-										  IsEnabled="False"
-										  MinWidth="200"
-										  Style="{StaticResource ToggleSwitchStyle}"
-										  Grid.Column="1"
-										  Grid.Row="1"/>
-						</Grid>
+						</StackPanel>
 					</local:OverviewSampleView>
 
 				</StackPanel>
@@ -163,7 +154,8 @@
 						<StackPanel Spacing="8">
 
 							<Button Content="Button" />
-							<Button Content="Text Button" Style="{StaticResource TextBlockButtonStyle}" />
+							<Button Content="Text Button"
+									Style="{StaticResource TextBlockButtonStyle}" />
 							<Button Style="{StaticResource NavigationBackButtonNormalStyle}" />
 
 						</StackPanel>
@@ -174,7 +166,8 @@
 						<StackPanel Spacing="8">
 
 							<TextBox PlaceholderText="TextBox" />
-							<TextBox PlaceholderText="Disabled" IsEnabled="False" />
+							<TextBox PlaceholderText="Disabled"
+									 IsEnabled="False" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -183,11 +176,16 @@
 					<local:OverviewSampleView SamplePageType="samples:CheckBoxSamplePage">
 						<StackPanel Spacing="8">
 
-							<CheckBox Content="Checked" IsChecked="True" />
-							<CheckBox Content="Unchecked" IsChecked="False" />
+							<CheckBox Content="Checked"
+									  IsChecked="True" />
+							<CheckBox Content="Unchecked"
+									  IsChecked="False" />
 							<CheckBox Content="Indeterminate"
 									  IsChecked="{x:Null}"
 									  IsThreeState="True" />
+							<CheckBox Content="Disabled"
+									  IsChecked="True"
+									  IsEnabled="False" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -196,9 +194,14 @@
 					<local:OverviewSampleView SamplePageType="samples:RadioButtonSamplePage">
 						<StackPanel Spacing="8">
 
-							<RadioButton Content="Checked" IsChecked="True" />
-							<RadioButton Content="Unchecked" />
-
+							<RadioButton GroupName="Fluent_RadioButton"
+										 Content="Checked"
+										 IsChecked="True" />
+							<RadioButton GroupName="Fluent_RadioButton"
+										 Content="Unchecked" />
+							<RadioButton Content="Disabled"
+										 IsChecked="True"
+										 IsEnabled="False" />
 						</StackPanel>
 					</local:OverviewSampleView>
 
@@ -206,8 +209,10 @@
 					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
 						<StackPanel Spacing="8">
 
-							<ToggleSwitch Header="ToggleSwitch" IsOn="True" />
-							<ToggleSwitch Header="Disabled" IsEnabled="False" />
+							<ToggleSwitch Header="ToggleSwitch"
+										  IsOn="True" />
+							<ToggleSwitch Header="Disabled"
+										  IsEnabled="False" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -222,7 +227,7 @@
 					<!-- Button -->
 					<local:OverviewSampleView SamplePageType="samples:ButtonSamplePage">
 						<StackPanel Spacing="8"
-                                    Padding="11,0">
+									Padding="11,0">
 
 							<Button Content="DEFAULT"
 									AutomationProperties.AutomationId="CupertinoButton"
@@ -237,9 +242,10 @@
 					<!-- TextBox -->
 					<local:OverviewSampleView SamplePageType="samples:TextBoxSamplePage">
 						<StackPanel Spacing="8"
-                                    Padding="11,0">
+									Padding="11,0">
 
-							<TextBox Style="{StaticResource CupertinoTextBoxStyle}" PlaceholderText="Placeholder single line" />
+							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
+									 PlaceholderText="Placeholder single line" />
 							<TextBox Style="{StaticResource CupertinoTextBoxStyle}"
 									 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent pretium augue ut lectus consequat lobortis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Pellentesque suscipit, diam eu aliquet egestas, dolor sem mattis tortor, eu congue augue ipsum et nulla."
 									 VerticalContentAlignment="Top"
@@ -264,6 +270,10 @@
 									  IsChecked="{x:Null}"
 									  IsThreeState="True"
 									  Style="{StaticResource CupertinoCheckBoxStyle}" />
+							<CheckBox Content="Disabled"
+									  IsChecked="True"
+									  IsEnabled="False"
+									  Style="{StaticResource CupertinoCheckBoxStyle}" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -271,12 +281,19 @@
 					<!-- RadioButton -->
 					<local:OverviewSampleView SamplePageType="samples:RadioButtonSamplePage">
 						<StackPanel Spacing="8"
-                                    Padding="11,0">
+									Padding="11,0">
 
-							<RadioButton Content="Checked"
+							<RadioButton GroupName="Cupertino_RadioButton"
+										 Content="Checked"
 										 IsChecked="True"
 										 Style="{StaticResource CupertinoRadioButtonStyle}" />
-							<RadioButton Content="Unchecked" Style="{StaticResource CupertinoRadioButtonStyle}" />
+							<RadioButton GroupName="Cupertino_RadioButton"
+										 Content="Unchecked"
+										 Style="{StaticResource CupertinoRadioButtonStyle}" />
+							<RadioButton Content="Disabled"
+										 IsChecked="True"
+										 IsEnabled="False"
+										 Style="{StaticResource CupertinoRadioButtonStyle}" />
 
 						</StackPanel>
 					</local:OverviewSampleView>
@@ -284,7 +301,7 @@
 					<!-- ToggleSwitch -->
 					<local:OverviewSampleView SamplePageType="samples:ToggleSwitchSamplePage">
 						<StackPanel Spacing="8"
-                                    Padding="11,0">
+									Padding="11,0">
 
 							<ToggleSwitch Header="ToggleSwitch"
 										  IsOn="True"

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
@@ -233,7 +233,7 @@
 												<ResourceDictionary>
 													<ResourceDictionary.MergedDictionaries>
 														<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-														<ResourceDictionary Source="FluentOverrides.xaml" />
+														<ResourceDictionary Source="ms-appx:///Views/Styles/FluentOverrides.xaml" />
 													</ResourceDictionary.MergedDictionaries>
 												</ResourceDictionary>
 											</ContentPresenter.Resources>

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -16,12 +16,12 @@
 	<ItemGroup>
 		<PackageReference Include="Svg.Skia" Version="0.5.18" />
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200-dev.13.gef3f523648" />
-		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Cupertino.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Material.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.Toolkit.Skia.WinUI" Version="4.0.0-dev.98" />

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -100,12 +100,12 @@
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200-dev.13.gef3f523648" />
-		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Cupertino.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.6.0-dev.2" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.6" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0-dev.1" />
 		<PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Material.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.Toolkit.Skia.WinUI" Version="4.0.0-dev.98" />

--- a/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
+++ b/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
@@ -20,8 +20,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="7.1.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
-		<PackageReference Include="Uno.Cupertino.WinUI" Version="3.0.0-dev.352" />
-		<PackageReference Include="Uno.Material.WinUI" Version="3.0.0-dev.352" />
+		<PackageReference Include="Uno.Cupertino.WinUI" Version="4.0.0-dev.126" />
+		<PackageReference Include="Uno.Material.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/Uno.Gallery/issues/901

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description
- Fix CheckBox, RadioButton, and ToggleSwitch controls labels not matching like it should
- Fix InteropServices.COMException - Cannot locate resource from 'ms-resource:///Files/FluentOverrides.xaml'
- Update Material/Cupertino packages


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on Windows.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
