### PR TITLE
fix: properly override implicit styles for muxc controls

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/App.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/App.xaml
@@ -21,6 +21,7 @@
 				<!-- Load WinUI resources -->
 				<!-- Load these resources after the Material/Cupertino resources. This ensures that the default Fluent styles will be used as the implicit styles. -->
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+				<ResourceDictionary Source="Views/Styles/FluentOverrides.xaml" />
 
 				<!-- Application's custom styles -->
 				<ResourceDictionary Source="Views/Colors.xaml" todo:note="define some colors\brushes, and images resources; not for color overriding" />

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/FluentOverrides.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/FluentOverrides.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
+	<!-- uno issue: 13398 -->
+	<!-- This ensures that the default Fluent styles for these controls will be used as the implicit styles -->
+	<!-- The implicit Fluent styles here are not included in the XamlControlsResources res-dict -->
+	<Style TargetType="muxc:PipsPager" />
+	<Style TargetType="muxc:ProgressRing" />
+	<Style TargetType="muxc:ProgressBar" />
+</ResourceDictionary>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/13398

`XamlControlsResources` does not include the default implicit styles for `muxc:` controls, they need to be explicitly re-defined in order to override the Material ones