### PR TITLE
fix(share): fix share button unresponsive on Overview for iOS and Android

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Controls/SamplePageLayout.cs
@@ -12,6 +12,8 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
+using Windows.ApplicationModel.DataTransfer;
+
 
 namespace Uno.Gallery
 {
@@ -166,10 +168,22 @@ namespace Uno.Gallery
 
 		private void OnShareClicked(Hyperlink sender, HyperlinkClickEventArgs args)
 		{
-#if (__IOS__ || __ANDROID__) && !NET6_0_OR_GREATER
-			var sample = DataContext as Sample;
-			_ = Deeplinking.BranchService.Instance.ShareSample(sample, _design);
-#endif
+			if (DataTransferManager.IsSupported())
+			{
+				var dataTransferManager = DataTransferManagerHelper.GetForCurrentView();
+				dataTransferManager.DataRequested += DataRequested_URI;
+				DataTransferManagerHelper.ShowShareUI();
+			}
+		}
+
+		private void DataRequested_URI(DataTransferManager sender, DataRequestedEventArgs args)
+		{
+			args.Request.Data.Properties.Title = "Uno Gallery - Share-Sample Title";
+			args.Request.Data.Properties.Description = "See this awesome project:";
+
+			args.Request.Data.SetWebLink(new Uri("https://gallery.platform.uno/"));
+
+			sender.DataRequested -= DataRequested_URI;
 		}
 
 		/// <summary>

--- a/Uno.Gallery/Uno.Gallery.Shared/Helpers/DataTransferManagerHelper.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Helpers/DataTransferManagerHelper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Windows.ApplicationModel.DataTransfer;
+using WinRT.Interop;
+using WinRT;
+
+namespace Uno.Gallery.Helpers
+{
+	public static class DataTransferManagerHelper
+	{
+		private static readonly Guid _dtm_iid = new Guid("a5caee9b-8708-49d1-8d36-67d25a8da00c");
+
+#if WINDOWS
+		static IDataTransferManagerInterop DataTransferManagerInterop => DataTransferManager.As<IDataTransferManagerInterop>();
+#endif
+
+		public static DataTransferManager GetForCurrentView()
+		{
+#if WINDOWS
+			IntPtr result;
+			var hwnd = WindowNative.GetWindowHandle(App.Instance.MainWindow);
+			result = DataTransferManagerInterop.GetForWindow(hwnd, _dtm_iid);
+			DataTransferManager dataTransferManager = MarshalInterface<DataTransferManager>.FromAbi(result);
+			return (dataTransferManager);
+#else
+			return DataTransferManager.GetForCurrentView();
+#endif
+		}
+
+		public static void ShowShareUI(ShareUIOptions options = null)
+		{
+#if WINDOWS
+			var hwnd = WindowNative.GetWindowHandle(App.Instance.MainWindow);
+			DataTransferManagerInterop.ShowShareUIForWindow(hwnd, options);
+#else
+			DataTransferManager.ShowShareUI(options);
+#endif
+		}
+
+#if WINDOWS
+		[ComImport]
+		[Guid("3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		public interface IDataTransferManagerInterop
+		{
+			IntPtr GetForWindow([In] IntPtr appWindow, [In] ref Guid riid);
+			void ShowShareUIForWindow(IntPtr appWindow, ShareUIOptions options);
+		}
+#endif
+	}
+}

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SharingSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SharingSamplePage.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Controls;
 using System.Runtime.InteropServices;
 using WinRT;
 using WinRT.Interop;
+using Uno.Gallery.Helpers;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -132,48 +133,5 @@ namespace Uno.Gallery.Views.Samples
 
 			sender.DataRequested -= DataRequested_TextLight;
 		}
-	}
-
-	public static class DataTransferManagerHelper
-	{
-		private static readonly Guid _dtm_iid = new Guid("a5caee9b-8708-49d1-8d36-67d25a8da00c");
-
-#if WINDOWS
-		static IDataTransferManagerInterop DataTransferManagerInterop => DataTransferManager.As<IDataTransferManagerInterop>();
-#endif
-
-		public static DataTransferManager GetForCurrentView()
-		{
-#if WINDOWS
-			IntPtr result;
-			var hwnd = WindowNative.GetWindowHandle(App.Instance.MainWindow); 
-			result = DataTransferManagerInterop.GetForWindow(hwnd, _dtm_iid);
-			DataTransferManager dataTransferManager = MarshalInterface<DataTransferManager>.FromAbi(result);
-			return (dataTransferManager);
-#else
-			return DataTransferManager.GetForCurrentView();
-#endif
-		}
-
-		public static void ShowShareUI(ShareUIOptions options = null)
-		{
-#if WINDOWS
-			var hwnd = WindowNative.GetWindowHandle(App.Instance.MainWindow); 
-			DataTransferManagerInterop.ShowShareUIForWindow(hwnd, options);
-#else
-			DataTransferManager.ShowShareUI(options);
-#endif
-		}
-
-#if WINDOWS
-		[ComImport]
-		[Guid("3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8")]
-		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-		public interface IDataTransferManagerInterop
-		{
-			IntPtr GetForWindow([In] IntPtr appWindow, [In] ref Guid riid);
-			void ShowShareUIForWindow(IntPtr appWindow, ShareUIOptions options);
-		}
-#endif
 	}
 }

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
@@ -293,7 +293,7 @@
 														   Style="{StaticResource BodyMedium}">
 											<Run Text="You can" />
 
-											<Hyperlink x:Name="PART_ShareHyperlink">
+											<Hyperlink x:Name="PART_ShareHyperlink" >
 												<Run Text="share" />
 											</Hyperlink>
 


### PR DESCRIPTION


GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/9012

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
**Share** button on Overview page is not working

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

**Share** button is working and shares the Lunk to UnoGallery app

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [x] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
Haven't tested iOS because it is not deploying to my physical device

