### PR TITLE
fix: checkbox double click

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/NeumorphicStyles.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/NeumorphicStyles.xaml
@@ -1509,7 +1509,9 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="CheckBox">
-					<Grid x:Name="Root">
+					<!--We need an invisible background because of this bug: https://github.com/unoplatform/uno/issues/13604-->
+					<Grid x:Name="Root"
+						  Background="Transparent">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal" />
@@ -1832,7 +1834,9 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="RadioButton">
-					<Grid x:Name="RootGrid">
+					<!--We need an invisible background because of this bug: https://github.com/unoplatform/uno/issues/13604-->
+					<Grid x:Name="RootGrid"
+						  Background="Transparent">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal" />


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/uno/issues/13557
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix


## What is the current behavior?
When you click the checkbox, it clicks the checkbox twice, making it look like it was not cliked on on android.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
It the click is only registered once, so it changes from checked to unchecked everytime you click on it.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
