### PR TITLE
fix(smtx): invalid xmlns declaration on attached property

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Extensions/XamlDisplayExtensions.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Extensions/XamlDisplayExtensions.cs
@@ -383,7 +383,7 @@ namespace ShowMeTheXAML
 
 			private static string ExtractXmlns(string xaml)
 			{
-				// extract/remove all xmlns declaration from the xaml,
+				// extract/remove all xmlns declarations from the xaml,
 				// and add them at the start, like so:
 				// xmlns:this="example.com"
 				// ...


### PR DESCRIPTION
GitHub Issue (If applicable): close unoplatform/ShowMeTheXAML#28

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
- xmlns declarations wont appear on attached property anymore
- xmlns declarations are now all grouped at the start of document, like:
	```xml
	xmlns:um="using:Uno.Material"
	...
	
	<Button>
		<um:ControlExtensions.Icon>
			<PathIcon Data="..." />
		<um:ControlExtensions.Icon>
	</Button>
	```

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested on Skia
- [x] Associated with an issue (GitHub or internal)