### PR TITLE
fix: FAB bouncing in the ShadowContainerSample

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ShadowContainerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ShadowContainerSamplePage.xaml
@@ -271,8 +271,33 @@
 								  Background="{ThemeResource SurfaceBrush}"
 								  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 
-					<controls:WrapPanel HorizontalSpacing="16"
-										VerticalSpacing="16">
+					<StackPanel x:Name="FABStackPanel"
+								Orientation="Horizontal"
+								Spacing="16">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="FormFactors">
+
+								<VisualState x:Name="Desktop">
+									<VisualState.StateTriggers>
+										<AdaptiveTrigger MinWindowWidth="{StaticResource DesktopAdaptiveThresholdWidth}" />
+									</VisualState.StateTriggers>
+									<VisualState.Setters>
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="Mobile">
+									<VisualState.StateTriggers>
+										<AdaptiveTrigger MinWindowWidth="0" />
+									</VisualState.StateTriggers>
+
+									<VisualState.Setters>
+										<Setter Target="FABStackPanel.Orientation"
+												Value="Vertical" />										
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						
 						<Button Style="{StaticResource NeumorphicFabSmallStyle}"
 								Content="Small">
 							<um:ControlExtensions.Icon>
@@ -292,7 +317,7 @@
 								<PathIcon Data="M24.334 13.7143H14.0483V24H10.6197V13.7143H0.333984V10.2857H10.6197V0H14.0483V10.2857H24.334V13.7143Z" />
 							</um:ControlExtensions.Icon>
 						</Button>
-					</controls:WrapPanel>
+					</StackPanel>
 				</smtx:XamlDisplay>
 			</DataTemplate>
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The buttons bounce 
![flashingbuttons](https://github.com/unoplatform/Uno.Gallery/assets/90481654/a31cc426-ee47-46ac-851b-eb4055cd0a3c)


## What is the new behavior?
They stay the same size.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on ~~UWP~~ WinUI.
- [ ] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/uno/issues/13557