### PR TITLE
chore: workaround for theme-switching rng failure

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Colors.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Colors.xaml
@@ -8,10 +8,12 @@
 		<ResourceDictionary x:Key="Light">
 			<x:String x:Key="UnoLogoImageSource">ms-appx:///Assets/UnoGalleryLogo_Light.png</x:String>
 			<x:String x:Key="OverviewImageSource">ms-appx:///Assets/uno-banner-light.png</x:String>
+			<SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource SurfaceColor}" />
 		</ResourceDictionary>
 		<ResourceDictionary x:Key="Dark">
 			<x:String x:Key="UnoLogoImageSource">ms-appx:///Assets/UnoGalleryLogo_Dark.png</x:String>
 			<x:String x:Key="OverviewImageSource">ms-appx:///Assets/uno-banner-dark.png</x:String>
+			<SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource SurfaceColor}" />
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 
@@ -27,8 +29,6 @@
 	<SolidColorBrush x:Key="SampleFourthBackgroundBrush"
 					 Color="{ThemeResource OutlineColor}"
 					 Opacity="0.5" />
-	<SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
-					 Color="{ThemeResource SurfaceColor}" />
 
 	<Color x:Key="UnoBlueColor">#FF229DFC</Color>
 	<Color x:Key="UnoPurpleColor">#FF7A69F5</Color>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ButtonSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ButtonSamplePage.xaml
@@ -9,7 +9,7 @@
 	  xmlns:todo="what should be done"
 	  mc:Ignorable="d todo">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ClipboardSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ClipboardSamplePage.xaml
@@ -21,7 +21,7 @@
 		</ResourceDictionary>
 	</Page.Resources>
 
-	<Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DisplayRequestSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DisplayRequestSamplePage.xaml
@@ -15,7 +15,7 @@
 	  mc:Ignorable="d android ios macos skia wasm"
 	  x:Name="page">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>
@@ -28,7 +28,7 @@
                                 <CheckBox Content="Keep screen on" Click="CheckBox_Click"/>
                                 <!--
 private DisplayRequest _displayRequest;
-								
+
 private void CheckBox_Click(object sender, RoutedEventArgs e)
 {
 	var checkBox = sender as CheckBox;
@@ -41,7 +41,7 @@ private void CheckBox_Click(object sender, RoutedEventArgs e)
 	{
 		_displayRequest.RequestRelease();
 	}
-}	
+}
 -->
                             </StackPanel>
                         </smtx:XamlDisplay>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ElevatedViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ElevatedViewSamplePage.xaml
@@ -18,7 +18,7 @@
 		</Style>
 	</Page.Resources>
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/LocalSettingsSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/LocalSettingsSamplePage.xaml
@@ -15,7 +15,7 @@
 		mc:Ignorable="d android ios macos skia wasm"
 		x:Name="page">
 
-	<Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/PasswordVaultSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/PasswordVaultSamplePage.xaml
@@ -15,7 +15,7 @@
 	  mc:Ignorable="d android ios macos skia wasm"
 	  x:Name="page">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SharingSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SharingSamplePage.xaml
@@ -15,7 +15,7 @@
 	  mc:Ignorable="d android ios macos skia wasm"
 	  x:Name="page">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SimpleOrientationSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/SimpleOrientationSamplePage.xaml
@@ -15,7 +15,7 @@
 	  mc:Ignorable="d android ios macos skia wasm"
 	  x:Name="page">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 			<local:SamplePageLayout.FluentTemplate>
 				<DataTemplate>
@@ -42,7 +42,7 @@
 								</Button>
 								<!-- C# code
 var simpleOrientation = SimpleOrientation.GetDefault();
-			
+
 if (simpleOrientation != null)
 {
 	simpleOrientation.OrientationChanged += SimpleOrientationSensor_OrientationChanged;

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TwoPaneViewSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TwoPaneViewSamplePage.xaml
@@ -24,7 +24,7 @@
 								</muxc:TwoPaneView.Pane1>
 
 								<muxc:TwoPaneView.Pane2>
-									<Border Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+									<Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 2</TextBlock>
 									</Border>
 								</muxc:TwoPaneView.Pane2>
@@ -42,7 +42,7 @@
 								</muxc:TwoPaneView.Pane1>
 
 								<muxc:TwoPaneView.Pane2>
-									<Border Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+									<Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 										<TextBlock FontSize="24" Padding="15">Pane 2</TextBlock>
 									</Border>
 								</muxc:TwoPaneView.Pane2>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/VibrationDeviceSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/VibrationDeviceSamplePage.xaml
@@ -15,7 +15,7 @@
 	  mc:Ignorable="d android ios macos skia wasm"
 	  x:Name="page">
 
-    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout IsDesignAgnostic="True">
 			<local:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): #974

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Certain pages with ApplicationPageBackgroundThemeBrush used at the page or page root level, can randomly fail to theme-switch properly.

## What is the new behavior?
Should not happen anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [ ] Tested on Android. (unable to reproduce to verify, even prior to the workaround)
- [ ] Tested on UWP.
- [x] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)