### PR TITLE
fix: Background for Tabbar Icon

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MaterialTopBarSampleNestedPage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/NestedPages/MaterialTopBarSampleNestedPage.xaml
@@ -5,7 +5,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  Background="{ThemeResource SurfaceBrush}">
 
 	<Grid>
 		<Grid.RowDefinitions>
@@ -42,32 +42,32 @@
 			<Grid x:Name="Home" Visibility="Collapsed">
 				<Border Background="LightGray">
 					<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-						<FontIcon Glyph="{StaticResource HomeIcon}" />
-						<TextBlock Text="Home" TextAlignment="Center" />
+						<FontIcon  Foreground="{StaticResource OnSurfaceBrush}"  Glyph="{StaticResource HomeIcon}" />
+						<TextBlock Foreground="{StaticResource OnSurfaceBrush}" Text="Home" TextAlignment="Center" />
 					</StackPanel>
 				</Border>
 			</Grid>
 			<Grid x:Name="Search" Visibility="Collapsed">
 				<Border Background="LightGray">
 					<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-						<FontIcon Glyph="{StaticResource SearchIcon}" />
-						<TextBlock Text="Search" TextAlignment="Center" />
+						<FontIcon  Foreground="{StaticResource OnSurfaceBrush}" Glyph="{StaticResource SearchIcon}" />
+						<TextBlock Foreground="{StaticResource OnSurfaceBrush}" Text="Search" TextAlignment="Center" />
 					</StackPanel>
 				</Border>
 			</Grid>
 			<Grid x:Name="Support" Visibility="Collapsed">
 				<Border Background="LightGray">
-					<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-						<FontIcon Glyph="{StaticResource SupportIcon}" />
-						<TextBlock Text="Support" TextAlignment="Center" />
+					<StackPanel  HorizontalAlignment="Center" VerticalAlignment="Center">
+						<FontIcon  Foreground="{StaticResource OnSurfaceBrush}"  Glyph="{StaticResource SupportIcon}" />
+						<TextBlock Foreground="{StaticResource OnSurfaceBrush}"   Text="Support" TextAlignment="Center" />
 					</StackPanel>
 				</Border>
 			</Grid>
 			<Grid x:Name="About" Visibility="Collapsed">
 				<Border Background="LightGray">
 					<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-						<FontIcon Glyph="{StaticResource AboutIcon}" />
-						<TextBlock Text="About" TextAlignment="Center" />
+						<FontIcon  Foreground="{StaticResource OnSurfaceBrush}"  Glyph="{StaticResource AboutIcon}" />
+						<TextBlock Foreground="{StaticResource OnSurfaceBrush}"  Text="About" TextAlignment="Center" />
 					</StackPanel>
 				</Border>
 			</Grid>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Gallery/issues/1032

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- [x] Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

## What is the current behavior?

Tabbar-For Material Top TabBar sample Page' the tab Icon and text color is not changing for dark theme


## What is the new behavior?

The Text and Icon color should change to black color for dark theme or the whole screen should change in black color.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
