### PR TITLE
feat: Enable TimePicker and DatePicker samples for all platforms

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -36,9 +36,9 @@
 		<PackageReference Include="Uno.Material.WinUI" Version="4.0.0-dev.126" />
 		<PackageReference Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
 		<PackageReference Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
-		<PackageReference Include="Uno.WinUI" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.0.0-dev.2366" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.1.0-dev.1549" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.1.0-dev.1549" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.Diagnostics.Eventing" Version="2.1.0-dev.1" />
@@ -46,10 +46,10 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Cupertino" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.99" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="5.1.0-dev.1549" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
-		<PackageReference Include="Uno.WinUI.Svg" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI.Svg" Version="5.1.0-dev.1549" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DatePickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DatePickerSamplePage.xaml
@@ -8,79 +8,83 @@
 	  xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:smtx="using:ShowMeTheXAML"
 	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:xamarin="http://uno.ui/xamarin"
+	  xmlns:not_win="http://uno.ui/not_win"
 	  xmlns:android="http://uno.ui/android"
-	  mc:Ignorable="d ios android xamarin mobile">
+	  mc:Ignorable="d ios android not_win mobile">
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 
 			<local:SamplePageLayout.MaterialTemplate>
-				<not_mobile:DataTemplate>
+				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Material"
-									  smtx:XamlDisplayExtensions.Header="DatePicker"
+									  smtx:XamlDisplayExtensions.Header="Default Material"
 									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 
 							<DatePicker Header="Set Date"
-										xamarin:UseNativeStyle="False"
+										not_win:UseNativeStyle="False"
 										HorizontalAlignment="Left"
 										Style="{StaticResource DatePickerStyle}" />
-							<DatePicker Header="Set Date"
-										xamarin:UseNativeStyle="False"
+							<DatePicker Header="DatePicker Disabled"
+										not_win:UseNativeStyle="False"
 										HorizontalAlignment="Left"
 										Style="{StaticResource DatePickerStyle}"
 										IsEnabled="False" />
 
 						</StackPanel>
 					</smtx:XamlDisplay>
-				</not_mobile:DataTemplate>
+				</DataTemplate>
 			</local:SamplePageLayout.MaterialTemplate>
 			<local:SamplePageLayout.FluentTemplate>
-				<not_mobile:DataTemplate>
+				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Fluent"
-									  smtx:XamlDisplayExtensions.Header="DatePicker"
+									  smtx:XamlDisplayExtensions.Header="Default"
+									  smtx:XamlDisplayExtensions.Description=" The DatePicker uses the Fluent style for the text button as well as the flyout picker (with UseNativeStyle set to False)."
 									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 
-							<DatePicker xamarin:UseNativeStyle="False" />
-							<DatePicker IsEnabled="False" xamarin:UseNativeStyle="False" />
+							<DatePicker not_win:UseNativeStyle="False" />
+							<DatePicker Header="DatePicker Disabled"
+										IsEnabled="False"
+										not_win:UseNativeStyle="False" />
 
 						</StackPanel>
 					</smtx:XamlDisplay>
-				</not_mobile:DataTemplate>
+				</DataTemplate>
 			</local:SamplePageLayout.FluentTemplate>
 			<local:SamplePageLayout.CupertinoTemplate>
-				<not_mobile:DataTemplate>
+				<DataTemplate>
 					<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Cupertino"
-									  smtx:XamlDisplayExtensions.Header="Default"
+									  smtx:XamlDisplayExtensions.Header="Default Cupertino"
 									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 
 							<DatePicker Header="Enter Date"
-										xamarin:UseNativeStyle="False"
+										not_win:UseNativeStyle="False"
 										HorizontalAlignment="Left"
 										Style="{StaticResource CupertinoDatePickerStyle}" />
-							<DatePicker Header="Enter Date"
+							<DatePicker Header="DatePicker Disabled"
 										IsEnabled="False"
-										xamarin:UseNativeStyle="False"
+										not_win:UseNativeStyle="False"
 										HorizontalAlignment="Left"
 										Style="{StaticResource CupertinoDatePickerStyle}" />
 
 						</StackPanel>
 					</smtx:XamlDisplay>
-				</not_mobile:DataTemplate>
+				</DataTemplate>
 			</local:SamplePageLayout.CupertinoTemplate>
 			<local:SamplePageLayout.NativeTemplate>
 				<mobile:DataTemplate>
 					<smtx:XamlDisplay UniqueKey="DatePickerSamplePage_Native"
-									  smtx:XamlDisplayExtensions.Header="Default"
-									  smtx:XamlDisplayExtensions.Description="The DatePicker is composed of two parts: the text button which uses the Fluent style, and the Flyout Picker which is native to the platform."
+									  smtx:XamlDisplayExtensions.Header="Default with Native picker"
+									  smtx:XamlDisplayExtensions.Description="The DatePicker is composed of two parts: the text button which uses the Fluent style, and the Flyout Picker which is native to the platform (with UseNativeStyle set to True by default)."
 									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 						<StackPanel Spacing="20">
 
-							<DatePicker xamarin:UseNativeStyle="True" />
-							<DatePicker IsEnabled="False" xamarin:UseNativeStyle="True" />
+							<DatePicker />
+							<DatePicker Header="DatePicker Disabled"
+										IsEnabled="False" />
 
 						</StackPanel>
 					</smtx:XamlDisplay>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DatePickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/DatePickerSamplePage.xaml.cs
@@ -15,9 +15,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace Uno.Gallery.Views.Samples
 {
-#if !__MACOS__
 	[SamplePage(SampleCategory.UIComponents, "DatePicker", Description = "This control allows users to pick a date value.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.datepicker")]
-#endif
 	public sealed partial class DatePickerSamplePage : Page
 	{
 		public DatePickerSamplePage()

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TimePickerSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TimePickerSamplePage.xaml
@@ -3,89 +3,79 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:Uno.Gallery"
 	  xmlns:smtx="using:ShowMeTheXAML"
-      xmlns:mobile="http://uno.ui/mobile" 
-      xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:mobile="http://uno.ui/mobile"
+	  xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:android="http://uno.ui/android"
-	  mc:Ignorable="d ios android mobile">
+	  xmlns:not_win="http://uno.ui/not_win"
+	  mc:Ignorable="d ios android mobile not_win">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <local:SamplePageLayout>
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:SamplePageLayout>
+			<!-- Material sample will be added when the TimePicker style is available in Material v2 -->
+			<!-- cf. https://github.com/unoplatform/Uno.Themes/issues/1329 -->
+			<!--<local:SamplePageLayout.MaterialTemplate>
+				<not_mobile:DataTemplate>
+					<StackPanel>
 
-            <local:SamplePageLayout.MaterialTemplate>
-                <not_mobile:DataTemplate>
-                    <StackPanel>
-
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Material_Default"
+						<smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Material_Default"
 										  smtx:XamlDisplayExtensions.Header="Default">
 
-                            <TimePicker Header="Set Time"
+							<TimePicker Header="Set Time"
 										Style="{StaticResource MaterialTimePickerStyle}" />
-                        </smtx:XamlDisplay>
+						</smtx:XamlDisplay>
 
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Material_Disabled"
+						<smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Material_Disabled"
 										  smtx:XamlDisplayExtensions.Header="Disabled">
 
-                            <TimePicker Header="Set Time"
+							<TimePicker Header="Set Time"
 										Style="{StaticResource MaterialTimePickerStyle}"
 										IsEnabled="False" />
-                        </smtx:XamlDisplay>
-                    </StackPanel>
-                </not_mobile:DataTemplate>
-            </local:SamplePageLayout.MaterialTemplate>
+						</smtx:XamlDisplay>
+			
+					</StackPanel>
+				</not_mobile:DataTemplate>
+			</local:SamplePageLayout.MaterialTemplate>-->
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Fluent"
+									  smtx:XamlDisplayExtensions.Header="Default"
+									  smtx:XamlDisplayExtensions.Description=" The TimePicker uses the Fluent style for the text button as well as the flyout picker (with UseNativeStyle set to False)."
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+						<StackPanel Spacing="20">
 
-            <local:SamplePageLayout.FluentTemplate>
-                <not_mobile:DataTemplate>
-                    <StackPanel>
+							<TimePicker not_win:UseNativeStyle="False" />
 
-                        <ios:TextBlock Text="The TimePicker is composed of two parts: the text button which uses the fluent style, and the flyout picker which is native to the platform."
-									   TextWrapping="Wrap" />
+							<TimePicker Header="TimePicker with 24h Clock"
+										ClockIdentifier="24HourClock"
+										not_win:UseNativeStyle="False" />
 
-                        <android:TextBlock Text="The TimePicker is composed of two parts: the text button which uses the fluent style, and the flyout picker which is native to the platform."
-										   TextWrapping="Wrap" />
+							<TimePicker Header="TimePicker Disabled"
+										IsEnabled="False"
+										not_win:UseNativeStyle="False" />
 
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Fluent_Default"
-										  smtx:XamlDisplayExtensions.Header="Default">
+						</StackPanel>
+					</smtx:XamlDisplay>
+				</DataTemplate>
+			</local:SamplePageLayout.FluentTemplate>
+			<local:SamplePageLayout.NativeTemplate>
+				<mobile:DataTemplate>
+					<smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Native"
+									  smtx:XamlDisplayExtensions.Header="Default with Native picker"
+									  smtx:XamlDisplayExtensions.Description="The TimePicker is composed of two parts: the text button which uses the fluent style, and the flyout picker which is native to the platform (with UseNativeStyle set to True by default)."
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+						<StackPanel Spacing="20">
 
-                            <TimePicker />
-                        </smtx:XamlDisplay>
-
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Fluent_Clock"
-										  smtx:XamlDisplayExtensions.Header="TimePicker with 24h Clock">
-
-                            <TimePicker ClockIdentifier="24HourClock" />
-                        </smtx:XamlDisplay>
-
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Fluent_Disabled"
-										  smtx:XamlDisplayExtensions.Header="Disabled">
-
-                            <TimePicker IsEnabled="False" />
-                        </smtx:XamlDisplay>
-                    </StackPanel>
-                </not_mobile:DataTemplate>
-            </local:SamplePageLayout.FluentTemplate>
-
-            <local:SamplePageLayout.NativeTemplate>
-                <mobile:DataTemplate>
-                    <StackPanel>
-                        <TextBlock Text="The TimePicker is composed of two parts: the text button which uses the Fluent style, and the Flyout Picker which is native to the platform." />
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Native_Default"
-										  smtx:XamlDisplayExtensions.Header="Default">
-
-                            <TimePicker Header="Set Time" />
-                        </smtx:XamlDisplay>
-
-                        <smtx:XamlDisplay UniqueKey="TimePickerSamplePage_Native_Disabled"
-										  smtx:XamlDisplayExtensions.Header="Disabled">
-
-                            <TimePicker Header="Set Time"
+							<TimePicker />
+							<TimePicker Header="TimePicker Disabled"
 										IsEnabled="False" />
-                        </smtx:XamlDisplay>
-                    </StackPanel>
-                </mobile:DataTemplate>
-            </local:SamplePageLayout.NativeTemplate>
-        </local:SamplePageLayout>
-    </Grid>
+
+						</StackPanel>
+					</smtx:XamlDisplay>
+				</mobile:DataTemplate>
+			</local:SamplePageLayout.NativeTemplate>
+		</local:SamplePageLayout>
+	</Grid>
 </Page>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TimePickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/TimePickerSamplePage.xaml.cs
@@ -16,10 +16,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace Uno.Gallery.Views.Samples
 {
-#if !__WASM__ && !__MACOS__
 	[SamplePage(SampleCategory.UIComponents, "TimePicker", Description = "This control allows users to pick a time value.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.timepicker")]
-#endif
-	[SampleConditional(SampleConditionals.Disabled, Reason = "todo: styles not implemented")]
 	public sealed partial class TimePickerSamplePage : Page
 	{
 		public TimePickerSamplePage()

--- a/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
+++ b/Uno.Gallery/Uno.Gallery.Skia.Gtk/Uno.Gallery.Skia.Gtk.csproj
@@ -28,17 +28,17 @@
 		<PackageReference Include="Uno.Toolkit.Skia.WinUI" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Cupertino" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.99" />		
-		<PackageReference Include="Uno.WinUI.Lottie" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.0.0-dev.2366" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.1.0-dev.1549" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.1.0-dev.1549" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.6" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
-		<PackageReference Include="Uno.WinUI.Svg" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI.Svg" Version="5.1.0-dev.1549" />
 		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.18" />
-		<PackageReference Include="Uno.WinUI.MediaPlayer.Skia.Gtk" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.WinUI.MediaPlayer.Skia.Gtk" Version="5.1.0-dev.1549" />
 
 	</ItemGroup>
 

--- a/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
+++ b/Uno.Gallery/Uno.Gallery.Wasm/Uno.Gallery.Wasm.csproj
@@ -113,12 +113,12 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Cupertino" Version="5.0.0-dev.99" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.99" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.MediaPlayer.WebAssembly" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="5.0.0-dev.2366" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.0.0-dev.2366" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="8.0.0-dev.252" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.0-dev.252" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.MediaPlayer.WebAssembly" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="5.1.0-dev.1549" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.1.0-dev.1549" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.0-dev.27" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="9.0.0-dev.27" />
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -127,7 +127,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.2366" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.1.0-dev.1549" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 

--- a/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
+++ b/Uno.Gallery/Uno.Gallery.Windows/Uno.Gallery.Windows.csproj
@@ -46,7 +46,7 @@
 			<Version>5.0.0-dev.99</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.WinUI">
-			<Version>5.0.0-dev.2366</Version>
+			<Version>5.1.0-dev.1549</Version>
 		</PackageReference>
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## Description

feat: Enable TimePicker and DatePicker samples for all platforms 
(now that the support was added in Uno core - https://github.com/unoplatform/uno/pull/14097)

- TimePicker example with fluent button as well as fluent style picker on Android:
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/6e8a0d3b-7d06-4025-8d67-a37ae827c742)
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/bc0821db-9937-4cf2-8fd1-4f64e034717d)


- TimePicker example with fluent button and native picker on Android:
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/7eb4c90f-b1ff-4cd2-a6e9-c7bbceddb4c7)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested on Skia.
- [X] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
