### PR TITLE
fix: Added Fluent override for the NativeTemplate to avoid seeing material styles for the native tab by default

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/Styles/SamplePageLayout.xaml
@@ -255,7 +255,18 @@
 														  VerticalAlignment="Stretch"
 														  Content="{TemplateBinding Content}"
 														  ContentTemplate="{TemplateBinding NativeTemplate}"
-														  Visibility="Collapsed" />
+														  Visibility="Collapsed">
+											<!-- Added the Fluent overrides for the NativeTemplate to avoid having Material styles overriding by default for a control -->
+											<!-- For example DatePicker sample should showcase fluent style by default but with native picker -->
+											<ContentPresenter.Resources>
+												<ResourceDictionary>
+													<ResourceDictionary.MergedDictionaries>
+														<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+														<ResourceDictionary Source="ms-appx:///Views/Styles/FluentOverrides.xaml" />
+													</ResourceDictionary.MergedDictionaries>
+												</ResourceDictionary>
+											</ContentPresenter.Resources>
+										</ContentPresenter>
 
 										<!-- Agnostic Content -->
 										<ContentPresenter x:Name="AgnosticContentPresenter"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Android/iOS (DatePicker - Native Tab)
For the native tab, the DatePicker button is using Material style instead of Fluent by default
 
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/37197c81-273a-4fab-8ff4-bd1ab548d2d2)
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/201790ff-bd77-40c4-ae92-ebafec340c1d)

## What is the new behavior?

Added Fluent override for the NativeTemplate to avoid seeing material styles for the native tab by default
![image](https://github.com/unoplatform/Uno.Gallery/assets/16295702/d74219be-4b4c-45d3-bed0-38e6e22eb431)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on UWP.
- [X] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)
