### PR TITLE
chore: Remove duplicate PackageReference for Uno.Extensions.Logging.OSLog and update SkiaSharp.Views.Uno.WinUI to latest stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="NunitXml.TestLogger" Version="3.0.131" />
     <PackageVersion Include="nventive.Nimue.Application.Packaging" Version="0.1.0-alpha.58" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
     <PackageVersion Include="Svg.Skia" Version="1.0.0.1" />
     <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />

--- a/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
+++ b/Uno.Gallery/Uno.Gallery.Mobile/Uno.Gallery.Mobile.csproj
@@ -85,9 +85,6 @@
 			</PropertyGroup>
 		</When>
 		<When Condition="'$(TargetFramework)'=='net7.0-ios'">
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-			</ItemGroup>
 			<ItemGroup Condition="'$(Configuration)'=='Release'">
 				<TrimmableAssembly Include="CommunityToolkit.WinUI.UI" />
 			</ItemGroup>
@@ -114,9 +111,6 @@
 			</ItemGroup>
 		</When>
 		<When Condition="'$(TargetFramework)'=='net7.0-maccatalyst'">
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-			</ItemGroup>
 			<PropertyGroup>
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14686 -->
 				<_LibMonoLinkMode>static</_LibMonoLinkMode>


### PR DESCRIPTION
- Remove duplicate PackageReference for Uno.Extensions.Logging.OSLog for net7.0-ios and net7.0-maccatalyst conditions as this reference is already added for every platform
- Update SkiaSharp.Views.Uno.WinUI to latest stable