### PR TITLE
Fix RadioButton GroupName for the LightweightStyling FluentTemplate & remove unnecessary SecondaryRadioButtonStyle

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/LightweightStylingSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/LightweightStylingSamplePage.xaml
@@ -434,18 +434,18 @@
 										  smtx:XamlDisplayExtensions.Description="The example below contrasts a default radio button style with a customized one, where the standard properties of foreground, ellipse and ellipse fill colors are overridden for different states (normal, pointer over, pressed and disabled)."
 										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
 							<StackPanel Spacing="40">
-								<RadioButton GroupName="RadioButton_Material_A"
+								<RadioButton GroupName="RadioButton_Fluent_A"
 											 Content="Default Radio Button Style - Unchecked" />
 
-								<RadioButton GroupName="RadioButton_Material_A"
+								<RadioButton GroupName="RadioButton_Fluent_A"
 											 IsChecked="True"
 											 Content="Default Radio Button Style - Checked" />
 
-								<RadioButton GroupName="RadioButton_Material_A"
+								<RadioButton GroupName="RadioButton_Fluent_A"
 											 Content="Default Radio Button Style - Disabled"
 											 IsEnabled="False" />
 
-								<RadioButton GroupName="RadioButton_Material_B"
+								<RadioButton GroupName="RadioButton_Fluent_B"
 											 Content="Overridden Radio Button Style - Unchecked">
 									<RadioButton.Resources>
 										<SolidColorBrush x:Key="RadioButtonForeground"
@@ -483,7 +483,7 @@
 									</RadioButton.Resources>
 								</RadioButton>
 
-								<RadioButton GroupName="RadioButton_Material_B"
+								<RadioButton GroupName="RadioButton_Fluent_B"
 											 IsChecked="True"
 											 Content="Overridden Radio Button Style - Checked">
 									<RadioButton.Resources>
@@ -522,7 +522,7 @@
 									</RadioButton.Resources>
 								</RadioButton>
 
-								<RadioButton GroupName="RadioButton_Material_B"
+								<RadioButton GroupName="RadioButton_Fluent_B"
 											 Content="Overridden Radio Button Style - Disabled"
 											 IsEnabled="False">
 									<RadioButton.Resources>

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/RadioButtonSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/RadioButtonSamplePage.xaml
@@ -39,66 +39,34 @@
 			</local:SamplePageLayout.FluentTemplate>
 			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
-					<StackPanel>
+					<smtx:XamlDisplay UniqueKey="RadioButtonSamplePage_Material"
+									  smtx:XamlDisplayExtensions.Header="Default"
+									  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
+						<StackPanel Spacing="10">
 
-						<smtx:XamlDisplay UniqueKey="RadioButtonSamplePage_Material"
-										  smtx:XamlDisplayExtensions.Header="Default"
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
-							<StackPanel Spacing="10">
+							<RadioButton GroupName="RadioButtonDemo_Material_1a"
+										 AutomationProperties.AutomationId="RadioButton_Material_Unchecked"
+										 Content="UNCHECKED"
+										 Style="{StaticResource RadioButtonStyle}" />
+							<RadioButton GroupName="RadioButtonDemo_Material_1a"
+										 AutomationProperties.AutomationId="RadioButton_Material_Checked"
+										 Content="CHECKED"
+										 IsChecked="True"
+										 Style="{StaticResource RadioButtonStyle}" />
+							<RadioButton GroupName="RadioButtonDemo_Material_1b"
+										 AutomationProperties.AutomationId="RadioButton_Material_Disabled_Unchecked"
+										 Content="DISABLED UNCHECKED"
+										 IsEnabled="False"
+										 Style="{StaticResource RadioButtonStyle}" />
+							<RadioButton GroupName="RadioButtonDemo_Material_1b"
+										 AutomationProperties.AutomationId="RadioButton_Material_Disabled_Checked"
+										 Content="DISABLED CHECKED"
+										 IsChecked="True"
+										 IsEnabled="False"
+										 Style="{StaticResource RadioButtonStyle}" />
 
-								<RadioButton GroupName="RadioButtonDemo_Material_1a"
-											 AutomationProperties.AutomationId="RadioButton_Material_Unchecked"
-											 Content="UNCHECKED"
-											 Style="{StaticResource RadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_1a"
-											 AutomationProperties.AutomationId="RadioButton_Material_Checked"
-											 Content="CHECKED"
-											 IsChecked="True"
-											 Style="{StaticResource RadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_1b"
-											 AutomationProperties.AutomationId="RadioButton_Material_Disabled_Unchecked"
-											 Content="DISABLED UNCHECKED"
-											 IsEnabled="False"
-											 Style="{StaticResource RadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_1b"
-											 AutomationProperties.AutomationId="RadioButton_Material_Disabled_Checked"
-											 Content="DISABLED CHECKED"
-											 IsChecked="True"
-											 IsEnabled="False"
-											 Style="{StaticResource RadioButtonStyle}" />
-
-							</StackPanel>
-						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="RadioButtonSamplePage_Material_Secondary"
-										  smtx:XamlDisplayExtensions.Header="Secondary"
-										  smtx:XamlDisplayExtensions.IgnorePath="XamlDisplay\StackPanel">
-							<StackPanel Spacing="10">
-
-								<RadioButton GroupName="RadioButtonDemo_Material_2a"
-											 AutomationProperties.AutomationId="RadioButton_Material_Secondary_Unchecked"
-											 Content="UNCHECKED"
-											 Style="{StaticResource SecondaryRadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_2a"
-											 AutomationProperties.AutomationId="RadioButton_Material_Secondary_Checked"
-											 Content="CHECKED"
-											 IsChecked="True"
-											 Style="{StaticResource SecondaryRadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_2b"
-											 AutomationProperties.AutomationId="RadioButton_Material_Secondary_Disabled_Unchecked"
-											 Content="DISABLED UNCHECKED"
-											 IsEnabled="False"
-											 Style="{StaticResource SecondaryRadioButtonStyle}" />
-								<RadioButton GroupName="RadioButtonDemo_Material_2b"
-											 AutomationProperties.AutomationId="RadioButton_Material_Secondary_Disabled_Checked"
-											 Content="DISABLED CHECKED"
-											 IsChecked="True"
-											 IsEnabled="False"
-											 Style="{StaticResource SecondaryRadioButtonStyle}" />
-
-							</StackPanel>
-						</smtx:XamlDisplay>
-
-					</StackPanel>
+						</StackPanel>
+					</smtx:XamlDisplay>
 				</DataTemplate>
 			</local:SamplePageLayout.MaterialTemplate>
 			<local:SamplePageLayout.CupertinoTemplate>


### PR DESCRIPTION
Closes #1109 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description
- Fix RadioButton GroupName for the LightweightStyling FluentTemplate
- Remove unnecessary SecondaryRadioButtonStyle sample as it was part of Material v1 and removed in v2

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested on iOS.
- [X] Tested on Wasm.
- [X] Tested on Android.
- [X] Tested on WinUI.
- [X] Tested in both **Light** and **Dark** themes.
- [X] Associated with an issue (GitHub or internal)

