### PR TITLE
fix: `Flyout` & `ContentDialog` Fluent styles

### DIFF
--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ContentDialogSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ContentDialogSamplePage.xaml
@@ -12,10 +12,10 @@
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<local:SamplePageLayout>
 
-			<local:SamplePageLayout.FluentTemplate>
+			<local:SamplePageLayout.MaterialTemplate>
 				<DataTemplate>
 					<StackPanel>
-						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Fluent_Default"
+						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Material_Default"
 										  smtx:XamlDisplayExtensions.Header="Default ContentDialog">
 
 							<Button Content="Open dialog"
@@ -34,7 +34,7 @@ private async void Button_Click(object sender, RoutedEventArgs e)
 -->
 						</smtx:XamlDisplay>
 
-						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Fluent_Title"
+						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Material_Title"
 										  smtx:XamlDisplayExtensions.Header="ContentDialog with Title">
 
 							<Button Content="Open dialog"
@@ -54,10 +54,95 @@ private async void Button_Click2(object sender, RoutedEventArgs e)
 -->
 						</smtx:XamlDisplay>
 
+						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Material_Prompt"
+										  smtx:XamlDisplayExtensions.Header="ContentDialog with Prompt">
+							<Button Content="Open dialog"
+									Click="Button_Click3" />
+							<!-- with the following C# code
+private async void Button_Click3(object sender, RoutedEventArgs e)
+{
+	var contentDialog = new ContentDialog()
+	{
+		Title = "Log out",
+		Content = "Are you sure you want to log out?",
+		PrimaryButtonText = "Log out",
+		CloseButtonText = "Cancel",
+		DefaultButton = ContentDialogButton.Primary,
+		XamlRoot = this.XamlRoot,
+	};
+
+	if (await contentDialog.ShowAsync() == ContentDialogResult.Primary)
+	{
+		// Log out
+	}
+	else
+	{
+		// Cancel
+	}
+}
+-->
+						</smtx:XamlDisplay>
+					</StackPanel>
+				</DataTemplate>
+			</local:SamplePageLayout.MaterialTemplate>
+
+			<local:SamplePageLayout.FluentTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<StackPanel.Resources>
+							<ResourceDictionary>
+								<ResourceDictionary.MergedDictionaries>
+									<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+								</ResourceDictionary.MergedDictionaries>
+							</ResourceDictionary>
+						</StackPanel.Resources>
+						
+						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Fluent_Default"
+										  smtx:XamlDisplayExtensions.Header="Default ContentDialog">
+
+							<Button Content="Open dialog"
+									Click="Button_Click"
+									Tag="Fluent" />
+							<!-- with the following C# code
+private async void Button_Click(object sender, RoutedEventArgs e)
+{
+	var contentDialog = new ContentDialog()
+	{
+		Content = "Hello world!",
+		PrimaryButtonText = "OK",
+		XamlRoot = this.XamlRoot
+	};
+	await contentDialog.ShowAsync();
+}
+-->
+						</smtx:XamlDisplay>
+
+						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Fluent_Title"
+										  smtx:XamlDisplayExtensions.Header="ContentDialog with Title">
+
+							<Button Content="Open dialog"
+									Click="Button_Click2"
+									Tag="Fluent" />
+							<!-- with the following C# code
+private async void Button_Click2(object sender, RoutedEventArgs e)
+{
+	var contentDialog = new ContentDialog
+	{
+		Title = "Notice",
+		Content = "This is a very important message.",
+		PrimaryButtonText = "OK",
+		XamlRoot = this.XamlRoot
+	};
+	await contentDialog.ShowAsync();
+}
+-->
+						</smtx:XamlDisplay>
+
 						<smtx:XamlDisplay UniqueKey="ContentDialogSamplePage_Fluent_Prompt"
 											  smtx:XamlDisplayExtensions.Header="ContentDialog with Prompt">
 							<Button Content="Open dialog"
-										Click="Button_Click3" />
+									Click="Button_Click3"
+									Tag="Fluent" />
 							<!-- with the following C# code
 private async void Button_Click3(object sender, RoutedEventArgs e)
 {

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ContentDialogSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/ContentDialogSamplePage.xaml.cs
@@ -31,8 +31,16 @@ namespace Uno.Gallery.Views.Samples
 			{
 				Content = "Hello world!",
 				PrimaryButtonText = "OK",
-				XamlRoot = this.XamlRoot
+				XamlRoot = this.XamlRoot,
 			};
+
+			if ((sender is Button button) && button.Tag is { } tag && tag.ToString() == "Fluent")
+			{
+				var resourceDictionary = new ResourceDictionary();
+				resourceDictionary.MergedDictionaries.Add(new XamlControlsResources());
+				contentDialog.Resources = resourceDictionary;
+			}
+
 			await contentDialog.ShowAsync();
 		}
 
@@ -45,6 +53,14 @@ namespace Uno.Gallery.Views.Samples
 				PrimaryButtonText = "OK",
 				XamlRoot = this.XamlRoot
 			};
+
+			if ((sender is Button button) && button.Tag is { } tag && tag.ToString() == "Fluent")
+			{
+				var resourceDictionary = new ResourceDictionary();
+				resourceDictionary.MergedDictionaries.Add(new XamlControlsResources());
+				contentDialog.Resources = resourceDictionary;
+			}
+
 			await contentDialog.ShowAsync();
 		}
 
@@ -59,6 +75,13 @@ namespace Uno.Gallery.Views.Samples
 				DefaultButton = ContentDialogButton.Primary,
 				XamlRoot = this.XamlRoot,
 			};
+
+			if ((sender is Button button) && button.Tag is { } tag && tag.ToString() == "Fluent")
+			{
+				var resourceDictionary = new ResourceDictionary();
+				resourceDictionary.MergedDictionaries.Add(new XamlControlsResources());
+				contentDialog.Resources = resourceDictionary;
+			}
 
 			if (await contentDialog.ShowAsync() == ContentDialogResult.Primary)
 			{

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/FlyoutSamplePage.xaml
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/FlyoutSamplePage.xaml
@@ -134,21 +134,45 @@
 			<local:SamplePageLayout.FluentTemplate>
 				<DataTemplate>
 					<StackPanel>
+						<StackPanel.Resources>
+							<ResourceDictionary>
+								<ResourceDictionary.MergedDictionaries>
+									<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+								</ResourceDictionary.MergedDictionaries>
 
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Flyout" smtx:XamlDisplayExtensions.Header="FlyoutPresenter">
+								<Style x:Key="FluentMenuFlyoutPresenterStyle"
+									   TargetType="MenuFlyoutPresenter">
+								</Style>
+								<Style x:Key="FluentMenuFlyoutItemStyle"
+									   TargetType="MenuFlyoutItem">
+								</Style>
+								<Style x:Key="FluentToggleMenuFlyoutItemStyle"
+									   TargetType="ToggleMenuFlyoutItem">
+								</Style>
+								<Style x:Key="FluentMenuFlyoutSeparatorStyle"
+									   TargetType="MenuFlyoutSeparator">
+								</Style>
+								<Style x:Key="FluentMenuFlyoutSubItemStyle"
+									   TargetType="MenuFlyoutSubItem">
+								</Style>
+								<Style x:Key="FluentFlyoutPresenterStyle"
+									   TargetType="FlyoutPresenter">
+									<Setter Property="ScrollViewer.HorizontalScrollMode"
+											Value="Disabled" />
+									<Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+											Value="Disabled" />
+									<Setter Property="Margin"
+											Value="16" />
+								</Style>
+							</ResourceDictionary>
+						</StackPanel.Resources>
+
+						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Flyout"
+										  smtx:XamlDisplayExtensions.Header="FlyoutPresenter">
 
 							<Button Content="Flyout">
 								<Button.Flyout>
-									<Flyout>
-										<Flyout.FlyoutPresenterStyle>
-											<Style TargetType="FlyoutPresenter">
-
-												<Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-												<Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-												<Setter Property="Margin" Value="16" />
-											</Style>
-										</Flyout.FlyoutPresenterStyle>
-
+									<Flyout FlyoutPresenterStyle="{StaticResource FluentFlyoutPresenterStyle}">
 										<TextBlock Style="{StaticResource BodyMedium}">
 											<TextBlock.Text>
 												Lorem ipsum dolor sit amet consectetur adipiscing, elit aliquam ullamcorper
@@ -164,72 +188,97 @@
 								</Button.Flyout>
 							</Button>
 						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Flyout_Icons" smtx:XamlDisplayExtensions.Header="MenuFlyout &amp; Icons">
+						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Flyout_Icons"
+										  smtx:XamlDisplayExtensions.Header="MenuFlyout &amp; Icons">
 							<Button Content="Open">
 								<Button.Flyout>
-									<MenuFlyout>
-
-										<MenuFlyoutItem Text="Like">
+									<MenuFlyout MenuFlyoutPresenterStyle="{StaticResource FluentMenuFlyoutPresenterStyle}">
+										<MenuFlyoutItem Text="Like"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}">
 											<MenuFlyoutItem.Icon>
 												<SymbolIcon Symbol="Like" />
 											</MenuFlyoutItem.Icon>
 										</MenuFlyoutItem>
-										<MenuFlyoutItem Text="Dislike">
+										<MenuFlyoutItem Text="Dislike"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}">
 											<MenuFlyoutItem.Icon>
 												<SymbolIcon Symbol="Dislike" />
 											</MenuFlyoutItem.Icon>
 										</MenuFlyoutItem>
 
-										<MenuFlyoutSeparator />
+										<MenuFlyoutSeparator Style="{StaticResource FluentMenuFlyoutSeparatorStyle}"/>
 
-										<MenuFlyoutItem Text="Calculator" Icon="Calculator" />
+										<MenuFlyoutItem Text="Calculator"
+														Icon="Calculator"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 										<MenuFlyoutItem Text="Camera"
 														Icon="Camera"
-														win:KeyboardAcceleratorTextOverride="Ctrl+C" />
+														win:KeyboardAcceleratorTextOverride="Ctrl+C"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 										<MenuFlyoutItem Text="Calendar"
 														Icon="Calendar"
 														IsEnabled="False"
-														win:KeyboardAcceleratorTextOverride="Ctrl+D" />
+														win:KeyboardAcceleratorTextOverride="Ctrl+D"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 									</MenuFlyout>
 								</Button.Flyout>
 							</Button>
 						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_MenuFlyout_Toggles" smtx:XamlDisplayExtensions.Header="MenuFlyout &amp; Toggles">
+						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_MenuFlyout_Toggles"
+										  smtx:XamlDisplayExtensions.Header="MenuFlyout &amp; Toggles">
 							<Button Content="Options">
 								<Button.Flyout>
-									<MenuFlyout>
+									<MenuFlyout MenuFlyoutPresenterStyle="{StaticResource FluentMenuFlyoutPresenterStyle}">
 
-										<MenuFlyoutItem Text="Clear History" win:KeyboardAcceleratorTextOverride="Ctrl+Shift+C" />
+										<MenuFlyoutItem Text="Clear History"
+														win:KeyboardAcceleratorTextOverride="Ctrl+Shift+C"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 
-										<MenuFlyoutSeparator />
+										<MenuFlyoutSeparator Style="{StaticResource FluentMenuFlyoutSeparatorStyle}"/>
 
-										<ToggleMenuFlyoutItem Text="Incognito Mode" IsChecked="True" />
+										<ToggleMenuFlyoutItem Text="Incognito Mode"
+															  IsChecked="True"
+															  Style="{StaticResource FluentToggleMenuFlyoutItemStyle}" />
 										<ToggleMenuFlyoutItem Text="Dark Mode"
 															  IsChecked="True"
-															  win:KeyboardAcceleratorTextOverride="Ctrl+D" />
+															  win:KeyboardAcceleratorTextOverride="Ctrl+D"
+															  Style="{StaticResource FluentToggleMenuFlyoutItemStyle}" />
 										<ToggleMenuFlyoutItem Text="High Contrast Mode"
 															  IsChecked="True"
-															  IsEnabled="False" />
+															  IsEnabled="False"
+															  Style="{StaticResource FluentToggleMenuFlyoutItemStyle}" />
 									</MenuFlyout>
 								</Button.Flyout>
 							</Button>
 						</smtx:XamlDisplay>
-						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Nested_MenuFlyout" smtx:XamlDisplayExtensions.Header="Nested MenuFlyout">
+						<smtx:XamlDisplay UniqueKey="FlyoutSamplePage_Fluent_Nested_MenuFlyout"
+										  smtx:XamlDisplayExtensions.Header="Nested MenuFlyout">
 							<Button Content="Help">
 								<Button.Flyout>
-									<MenuFlyout>
+									<MenuFlyout MenuFlyoutPresenterStyle="{StaticResource FluentMenuFlyoutPresenterStyle}">
 
-										<MenuFlyoutItem Text="View Help" />
-										<MenuFlyoutSubItem Text="Disabled" IsEnabled="False">
-											<MenuFlyoutItem Text="Can't be seen" />
+										<MenuFlyoutItem Text="View Help"
+														Style="{StaticResource FluentMenuFlyoutItemStyle}" />
+										<MenuFlyoutSubItem Text="Disabled"
+														   IsEnabled="False"
+														   Style="{StaticResource FluentMenuFlyoutSubItemStyle}">
+											<MenuFlyoutItem Text="Can't be seen"
+															Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 										</MenuFlyoutSubItem>
-										<MenuFlyoutSubItem Text="Send Feedback">
-											<MenuFlyoutItem Text="Report Problem" />
-											<MenuFlyoutItem Text="Suggest Feature" />
-											<MenuFlyoutSubItem Text="Settings">
-												<MenuFlyoutItem Text="Auto Save" />
-												<MenuFlyoutItem Text="Start Up" />
-												<MenuFlyoutItem Text="Font and Colors" />
+										<MenuFlyoutSubItem Text="Send Feedback"
+														   Style="{StaticResource FluentMenuFlyoutSubItemStyle}">
+											<MenuFlyoutItem Text="Report Problem"
+															Style="{StaticResource FluentMenuFlyoutItemStyle}" />
+											<MenuFlyoutItem Text="Suggest Feature"
+															Style="{StaticResource FluentMenuFlyoutItemStyle}" />
+											<MenuFlyoutSubItem Text="Settings"
+															   Style="{StaticResource FluentMenuFlyoutSubItemStyle}">
+												<MenuFlyoutItem Text="Auto Save"
+																Style="{StaticResource FluentMenuFlyoutItemStyle}"/>
+												<MenuFlyoutItem Text="Start Up"
+																Style="{StaticResource FluentMenuFlyoutItemStyle}" />
+												<MenuFlyoutItem Text="Font and Colors"
+																Style="{StaticResource FluentMenuFlyoutItemStyle}" />
 											</MenuFlyoutSubItem>
 										</MenuFlyoutSubItem>
 

--- a/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/FlyoutSamplePage.xaml.cs
+++ b/Uno.Gallery/Uno.Gallery.Shared/Views/SamplePages/FlyoutSamplePage.xaml.cs
@@ -1,26 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+﻿using Microsoft.UI.Xaml.Controls;
 
-namespace Uno.Gallery.Views.Samples
+namespace Uno.Gallery.Views.Samples;
+
+[SamplePage(SampleCategory.UIComponents, "Flyout", Description = "A flyout is a UI container that can be light dismissed. It can contain other flyouts or context menus to create a nested experience.", DocumentationLink = "https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/dialogs-and-flyouts/flyouts")]
+public sealed partial class FlyoutSamplePage : Page
 {
-	[SamplePage(SampleCategory.UIComponents, "Flyout", Description = "A flyout is a UI container that can be light dismissed. It can contain other flyouts or context menus to create a nested experience.", DocumentationLink = "https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/dialogs-and-flyouts/flyouts")]
-	public sealed partial class FlyoutSamplePage : Page
+	public FlyoutSamplePage()
 	{
-		public FlyoutSamplePage()
-		{
-			this.InitializeComponent();
-		}
+		this.InitializeComponent();
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1094 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

![image](https://github.com/unoplatform/Uno.Gallery/assets/78549750/122da538-9979-423a-8c90-ba076f211d88)

![image](https://github.com/unoplatform/Uno.Gallery/assets/78549750/7cc8697b-66d0-4d56-b8f1-2e9e66cbe33e)

+ Adds support for `ContentDialog` Material theme.


<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)