### PR TITLE
fix: Ensure Fluent resources for AutoSuggestBox popups

### DIFF
--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml
@@ -145,6 +145,7 @@ public List<Sample> GetSuggestedItems(string searchQuery)
 
 								<StackPanel Spacing="4"
 											Margin="0,20,0,0"
+											MaxWidth="300"
 											Visibility="{Binding Data.SearchBoxSelectedItem, Converter={StaticResource NullToCollapsed}}">
 
 									<TextBlock Text="{Binding Data.SearchBoxSelectedItem.Title}"

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Uno.Gallery.ViewModels;
 using Microsoft.UI.Xaml.Controls;
+using Uno.Gallery.Helpers;
+using Microsoft.UI.Xaml.Media;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -16,13 +18,10 @@ namespace Uno.Gallery.Views.Samples
 
 		private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 		{
-			//This check can be removed when https://github.com/unoplatform/uno/issues/11635 is fixed
-#if !__ANDROID__ && !__IOS__
 			if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
 			{
 				return;
 			}
-#endif
 
 			if (string.IsNullOrEmpty(sender.Text))
 			{
@@ -31,6 +30,7 @@ namespace Uno.Gallery.Views.Samples
 
 			if (((Sample)DataContext).Data is AutoSuggestBoxSamplePageViewModel viewModel)
 			{
+				EnsureFluentResourcesForPopups(sender);
 				sender.ItemsSource = viewModel.GetSuggestedItems(sender.Text).Select(sample => sample.Title).ToList();
 			}
 		}
@@ -46,16 +46,14 @@ namespace Uno.Gallery.Views.Samples
 
 		private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 		{
-			//This check can be removed when https://github.com/unoplatform/uno/issues/11635 is fixed
-#if !__ANDROID__ && !__IOS__
 			if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
 			{
 				return;
 			}
-#endif
 
 			if (((Sample)DataContext).Data is AutoSuggestBoxSamplePageViewModel viewModel)
 			{
+				EnsureFluentResourcesForPopups(sender);
 				sender.ItemsSource = viewModel.GetSuggestedItems(sender.Text);
 			}
 		}

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -80,6 +80,18 @@ namespace Uno.Gallery.Views.Samples
 				viewModel.SearchBoxSelectedItem = (Sample)args.SelectedItem;
 			}
 		}
+
+		// This workaround is necessary since the app's main theme is Material and we need to ensure it displays with Fluent styles
+		private void EnsureFluentResourcesForPopups(AutoSuggestBox sender)
+		{
+			if (sender.IsSuggestionListOpen)
+			{
+				var popup = VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot).FirstOrDefault();
+
+				popup.EnsureXamlControlsResources(true);
+				(popup.Child as Border).EnsureXamlControlsResources(true);
+			}
+		}
 	}
 
 	public class AutoSuggestBoxSamplePageViewModel : ViewModelBase


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Gallery/issues/1122, closes https://github.com/unoplatform/Uno.Gallery/issues/1069

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?
> !NOTE
> Blocker: Currently the **Style not being picked up by the items in the popup, unless opened twice**

Fixes the issues with indentation of AutoSuggestBox popups.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [x] Tested on Android.
- [x] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issues (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->