### PR TITLE
fix: Outlined TextBox Disabled

### DIFF
--- a/Uno.Gallery/Views/SamplePages/TextBoxSamplePage.xaml
+++ b/Uno.Gallery/Views/SamplePages/TextBoxSamplePage.xaml
@@ -138,6 +138,7 @@
 										 Style="{StaticResource OutlinedTextBoxStyle}"
 										 AutomationProperties.AutomationId="TextBox_Outlined_Material" />
 								<TextBox Text="Disabled"
+										 IsEnabled="False"
 										 Style="{StaticResource OutlinedTextBoxStyle}"
 										 AutomationProperties.AutomationId="TextBox_Outlined_Disabled_Material" />
 								<TextBox PlaceholderText="Placeholder"


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Themes/issues/1457

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:
 -->
## What is the current behavior?
The Outlined `TextBox` that should be disabled is enabled.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
The Outlined `TextBox` that should be disabled is now disabled.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
