### PR TITLE
build: add windowssdkpackageversion

### DIFF
--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -23,6 +23,7 @@
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
+		<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion> 
 		<!--
 		If you encounter this error message:
 


### PR DESCRIPTION
Fixing errors from latest winappsdk 1.6:

C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error : This version of the Windows App SDK requires Microsoft.Windows.SDK.NET.Ref 10.0.19041.38 or later. [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :     Please update to .NET SDK 6.0.134, 6.0.426, 8.0.109, 8.0.305 or 8.0.402 (or later). [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :     Or add a temporary Microsoft.Windows.SDK.NET.Ref reference which can be added with: [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :         <PropertyGroup> [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :             <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion> [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :         </PropertyGroup> [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): error :  [D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj]
