### PR TITLE
fix: Ensure Fluent resources for AutoSuggestBox on WASM

### DIFF
--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -24,12 +24,6 @@ namespace Uno.Gallery.Views.Samples
 
 			foreach (var item in desc)
 			{
-				// Windows specific 
-				//var popups = VisualTreeHelperEx.GetDescendants(item).OfType<Popup>();
-				//foreach (var popup in popups)
-				//{
-				//	popup.EnsureXamlControlsResources(true);
-				//}
 
 				var border = item.GetTemplateChild("SuggestionsContainer") as Border;
 				border?.EnsureXamlControlsResources(true);

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Uno.Gallery.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using Uno.Gallery.Helpers;
+using Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -18,14 +19,22 @@ namespace Uno.Gallery.Views.Samples
 
 		private void AutoSuggestBoxSamplePage_Loaded(object sender, RoutedEventArgs e)
 		{
+#if HAS_UNO
 			var desc = VisualTreeHelperEx.GetDescendants(this).OfType<AutoSuggestBox>();
 
 			foreach (var item in desc)
 			{
+				// Windows specific 
+				//var popups = VisualTreeHelperEx.GetDescendants(item).OfType<Popup>();
+				//foreach (var popup in popups)
+				//{
+				//	popup.EnsureXamlControlsResources(true);
+				//}
+
 				var border = item.GetTemplateChild("SuggestionsContainer") as Border;
 				border?.EnsureXamlControlsResources(true);
 			}
-
+#endif
 			Loaded -= AutoSuggestBoxSamplePage_Loaded;
 		}
 

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Uno.Gallery.ViewModels;
 using Microsoft.UI.Xaml.Controls;
+using Uno.Gallery.Helpers;
 
 namespace Uno.Gallery.Views.Samples
 {
@@ -12,17 +13,23 @@ namespace Uno.Gallery.Views.Samples
 		public AutoSuggestBoxSamplePage()
 		{
 			this.InitializeComponent();
+			Loaded += AutoSuggestBoxSamplePage_Loaded;
+		}
+
+		private void AutoSuggestBoxSamplePage_Loaded(object sender, RoutedEventArgs e)
+		{
+			// set Fluent styles for the AutoSuggestBox popup.
+			var border = GetTemplateChild("SuggestionsContainer") as Border;
+			border?.EnsureXamlControlsResources(true);
+			Loaded -= AutoSuggestBoxSamplePage_Loaded;
 		}
 
 		private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 		{
-			//This check can be removed when https://github.com/unoplatform/uno/issues/11635 is fixed
-#if !__ANDROID__ && !__IOS__
 			if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
 			{
 				return;
 			}
-#endif
 
 			if (string.IsNullOrEmpty(sender.Text))
 			{
@@ -31,7 +38,7 @@ namespace Uno.Gallery.Views.Samples
 
 			if (((Sample)DataContext).Data is AutoSuggestBoxSamplePageViewModel viewModel)
 			{
-				sender.ItemsSource = viewModel.GetSuggestedItems(sender.Text).Select(sample => sample.Title).ToList();
+				sender.ItemsSource = viewModel.GetSuggestedItems(sender.Text)?.Select(sample => sample.Title).ToList();
 			}
 		}
 
@@ -39,20 +46,17 @@ namespace Uno.Gallery.Views.Samples
 		{
 			if (((Sample)DataContext).Data is AutoSuggestBoxSamplePageViewModel viewModel)
 			{
-				viewModel.SelectedString = args.SelectedItem.ToString();
+				viewModel.SelectedString = args.SelectedItem.ToString() ?? string.Empty;
 			}
 
 		}
 
 		private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 		{
-			//This check can be removed when https://github.com/unoplatform/uno/issues/11635 is fixed
-#if !__ANDROID__ && !__IOS__
 			if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
 			{
 				return;
 			}
-#endif
 
 			if (((Sample)DataContext).Data is AutoSuggestBoxSamplePageViewModel viewModel)
 			{
@@ -88,7 +92,7 @@ namespace Uno.Gallery.Views.Samples
 
 		public Sample SearchBoxSelectedItem { get => GetProperty<Sample>(); set => SetProperty(value); }
 
-		public List<Sample> GetSuggestedItems(string searchQuery)
+		public List<Sample>? GetSuggestedItems(string searchQuery)
 		{
 			if (string.IsNullOrEmpty(searchQuery))
 			{

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -18,9 +18,14 @@ namespace Uno.Gallery.Views.Samples
 
 		private void AutoSuggestBoxSamplePage_Loaded(object sender, RoutedEventArgs e)
 		{
-			// set Fluent styles for the AutoSuggestBox popup.
-			var border = GetTemplateChild("SuggestionsContainer") as Border;
-			border?.EnsureXamlControlsResources(true);
+			var desc = VisualTreeHelperEx.GetDescendants(this).OfType<AutoSuggestBox>();
+
+			foreach (var item in desc)
+			{
+				var border = item.GetTemplateChild("SuggestionsContainer") as Border;
+				border?.EnsureXamlControlsResources(true);
+			}
+
 			Loaded -= AutoSuggestBoxSamplePage_Loaded;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

https://github.com/unoplatform/uno/issues/15967

## PR Type

What kind of change does this PR introduce?

Forces Fluent style on AutosuggestBox popup in Wasm.

- Bugfix

## What is the current behavior?

Autosuggest box has Material styles applied.


## What is the new behavior?

When the page loads gets the Border's popup control via `GetTemplateChild` and applies `EnsureXamlControlsResources()` method.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [x] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [x] Associated with an issue (GitHub or internal)

## Other information

I got the name of the Border from the microsoft repo.

https://github.com/microsoft/microsoft-ui-xaml/blob/d74a0332cf0d5e58f12eddce1070fa7a79b4c2db/src/controls/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp#L8-L13

Internal Issue (If applicable):
https://github.com/unoplatform/uno/issues/15967
