### PR TITLE
chore: workaround for __ResourceOwner_2 build errors

### DIFF
--- a/Uno.Gallery/Views/SamplePages/SwipeControlSamplePage.xaml
+++ b/Uno.Gallery/Views/SamplePages/SwipeControlSamplePage.xaml
@@ -1,12 +1,13 @@
-﻿<Page
-	x:Class="Uno.Gallery.Views.Samples.SwipeControlSamplePage"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="using:Uno.Gallery"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-	xmlns:smtx="using:ShowMeTheXAML"
-	mc:Ignorable="d">
+﻿<Page x:Class="Uno.Gallery.Views.Samples.SwipeControlSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Gallery"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:smtx="using:ShowMeTheXAML"
+	  mc:Ignorable="d">
+
+	<!-- #19745: SwipeItem(DependencyObject) with event handler cannot be stored within res-dict -->
 
 	<!-- Samples adapted from Microsoft XAML Controls Gallery: -->
 	<!-- https://github.com/microsoft/Xaml-Controls-Gallery -->
@@ -21,30 +22,30 @@
 										  smtx:XamlDisplayExtensions.Header="Swipe to reveal actions">
 							<Border>
 								<Border.Resources>
-									<FontIconSource x:Key="AcceptIcon" 
-													Glyph="&#xE10B;"/>
-									<FontIconSource x:Key="FlagIcon" 
-													Glyph="&#xE129;"/>
-
-									<SwipeItems x:Key="leftItems" 
-												Mode="Reveal">
-										<SwipeItem Text="Accept" 
-												   IconSource="{StaticResource AcceptIcon}" 
-												   Invoked="Accept_ItemInvoked"/>
-										<SwipeItem Text="Flag" 
-												   IconSource="{StaticResource FlagIcon}" 
-												   Invoked="Flag_ItemInvoked"/>
-									</SwipeItems>
+									<FontIconSource x:Key="AcceptIcon"
+													Glyph="&#xE10B;" />
+									<FontIconSource x:Key="FlagIcon"
+													Glyph="&#xE129;" />
 								</Border.Resources>
-								<SwipeControl BorderThickness="1" 
-											  LeftItems="{StaticResource leftItems}" 
-											  BorderBrush="{ThemeResource ButtonBackground}" 
-											  Margin="12" 
+								<SwipeControl BorderThickness="1"
+											  BorderBrush="{ThemeResource ButtonBackground}"
+											  Margin="12"
 											  Height="68">
-									<TextBlock Text="Swipe Right" 
+									<SwipeControl.LeftItems>
+										<SwipeItems Mode="Reveal">
+											<SwipeItem Text="Accept"
+													   IconSource="{StaticResource AcceptIcon}"
+													   Invoked="Accept_ItemInvoked" />
+											<SwipeItem Text="Flag"
+													   IconSource="{StaticResource FlagIcon}"
+													   Invoked="Flag_ItemInvoked" />
+										</SwipeItems>
+									</SwipeControl.LeftItems>
+									
+									<TextBlock Text="Swipe Right"
 											   Margin="12"
-											   HorizontalAlignment="Center" 
-											   VerticalAlignment="Center"/>
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
 								</SwipeControl>
 							</Border>
 						</smtx:XamlDisplay>
@@ -54,25 +55,26 @@
 										  smtx:XamlDisplayExtensions.Header="Swipe to invoke">
 							<Border>
 								<Border.Resources>
-									<FontIconSource x:Key="ArchiveIcon" 
-													Glyph="&#xE7B8;"/>
-									<SwipeItems x:Key="rightItems" 
-												Mode="Execute">
-										<SwipeItem Text="Archive" 
-												   IconSource="{StaticResource ArchiveIcon}"
-												   BehaviorOnInvoked="Close"
-												   Invoked="DeleteOne_ItemInvoked"/>
-									</SwipeItems>
+									<FontIconSource x:Key="ArchiveIcon"
+													Glyph="&#xE7B8;" />
 								</Border.Resources>
-								<SwipeControl BorderThickness="1" 
+								<SwipeControl BorderThickness="1"
 											  BorderBrush="{ThemeResource ButtonBackground}"
-											  RightItems="{StaticResource rightItems}"
-											  Margin="12" 
+											  Margin="12"
 											  Height="68">
-									<TextBlock Text="Swipe Left" 
+									<SwipeControl.RightItems>
+										<SwipeItems Mode="Execute">
+											<SwipeItem Text="Archive"
+													   IconSource="{StaticResource ArchiveIcon}"
+													   BehaviorOnInvoked="Close"
+													   Invoked="DeleteOne_ItemInvoked" />
+										</SwipeItems>
+									</SwipeControl.RightItems>
+
+									<TextBlock Text="Swipe Left"
 											   Margin="12"
-											   HorizontalAlignment="Center" 
-											   VerticalAlignment="Center"/>
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
 								</SwipeControl>
 							</Border>
 						</smtx:XamlDisplay>
@@ -80,51 +82,52 @@
 						<!-- Custom swipe in a ListView -->
 						<smtx:XamlDisplay UniqueKey="SwipeControlSamplePage_FluentCustomSwipe"
 										  smtx:XamlDisplayExtensions.Header="Custom swipe in a ListView">
-							<ListView x:Name="lv" 
+							<ListView x:Name="lv"
 									  Loaded="lv_Loaded"
-									  Height="300" 
+									  Height="300"
 									  SelectionMode="None"
 									  Margin="12">
 								<ListView.Resources>
-									<FontIconSource x:Key="ReplyAllIcon" 
-													Glyph="&#xE8C2;"/>
-									<FontIconSource x:Key="ReadIcon" 
-													Glyph="&#xE8C3;"/>
-									<FontIconSource x:Key="DeleteIcon" 
-													Glyph="&#xE107;"/>
+									<FontIconSource x:Key="ReplyAllIcon"
+													Glyph="&#xE8C2;" />
+									<FontIconSource x:Key="ReadIcon"
+													Glyph="&#xE8C3;" />
+									<FontIconSource x:Key="DeleteIcon"
+													Glyph="&#xE107;" />
 
-									<SwipeItems x:Key="left" 
+									<SwipeItems x:Key="left"
 												Mode="Reveal">
-										<SwipeItem Text="Reply All" 
+										<SwipeItem Text="Reply All"
 												   IconSource="{StaticResource ReplyAllIcon}"
-												   Background="#FF3e6fa7" 
-												   Foreground="White"/>
-										<SwipeItem Text="Open" 
+												   Background="#FF3e6fa7"
+												   Foreground="White" />
+										<SwipeItem Text="Open"
 												   IconSource="{StaticResource ReadIcon}"
-												   Background="#FFff9501" 
-												   Foreground="White"/>
-									</SwipeItems>
-									<SwipeItems x:Key="right" 
-												Mode="Execute">
-										<SwipeItem Text="Delete" 
-												   IconSource="{StaticResource DeleteIcon}"
-												   Background="#FFF4B183" 
-												   Invoked="DeleteItem_ItemInvoked"/>
+												   Background="#FFff9501"
+												   Foreground="White" />
 									</SwipeItems>
 								</ListView.Resources>
 
 								<ListView.ItemTemplate>
 									<DataTemplate>
-										<SwipeControl BorderThickness="0,1,0,0" 
-													  BorderBrush="{ThemeResource ButtonBackground}" 
+										<SwipeControl BorderThickness="0,1,0,0"
+													  BorderBrush="{ThemeResource ButtonBackground}"
 													  Height="68"
-													  LeftItems="{StaticResource left}"
-													  RightItems="{StaticResource right}">
+													  LeftItems="{StaticResource left}">
+											<SwipeControl.RightItems>
+												<SwipeItems Mode="Execute">
+													<SwipeItem Text="Delete"
+															   IconSource="{StaticResource DeleteIcon}"
+															   Background="#FFF4B183"
+															   Invoked="DeleteItem_ItemInvoked" />
+												</SwipeItems>
+											</SwipeControl.RightItems>
+
 											<TextBlock Text="{Binding}"
-													   FontSize="24" 
+													   FontSize="24"
 													   Margin="12"
-													   HorizontalAlignment="Stretch" 
-													   VerticalAlignment="Center"/>
+													   HorizontalAlignment="Stretch"
+													   VerticalAlignment="Center" />
 										</SwipeControl>
 									</DataTemplate>
 								</ListView.ItemTemplate>
@@ -136,35 +139,30 @@
 										  smtx:XamlDisplayExtensions.Header="SwipeItem with gradient background">
 							<Border>
 								<Border.Resources>
-									<FontIconSource x:Key="LockIcon" 
-													Glyph="&#xE107;"/>
-									<LinearGradientBrush x:Key="PurpleGradient" 
-														 StartPoint="0,0.5" 
-														 EndPoint="1,0.5">
-										<GradientStop Color="#ff8990f9" 
-													  Offset="0.0"/>
-										<GradientStop Color="#ff5b66fb" 
-													  Offset="0.5"/>
-										<GradientStop Color="#ff5c1df4" 
-													  Offset="1.0"/>
+									<FontIconSource x:Key="LockIcon"
+													Glyph="&#xE107;" />
+									<LinearGradientBrush x:Key="PurpleGradient" StartPoint="0,0.5" EndPoint="1,0.5">
+										<GradientStop Color="#ff8990f9" Offset="0.0" />
+										<GradientStop Color="#ff5b66fb" Offset="0.5" />
+										<GradientStop Color="#ff5c1df4" Offset="1.0" />
 									</LinearGradientBrush>
-									<SwipeItems x:Key="right" 
-													Mode="Execute">
-										<SwipeItem Text="Lock" 
-													   Background="{StaticResource PurpleGradient}"
-													   BehaviorOnInvoked="Close" 
-													   IconSource="{StaticResource LockIcon}"/>
+									<SwipeItems x:Key="right"
+												Mode="Execute">
+										<SwipeItem Text="Lock"
+												   Background="{StaticResource PurpleGradient}"
+												   BehaviorOnInvoked="Close"
+												   IconSource="{StaticResource LockIcon}" />
 									</SwipeItems>
 								</Border.Resources>
-								<SwipeControl BorderThickness="1" 
+								<SwipeControl BorderThickness="1"
 											  BorderBrush="{ThemeResource ButtonBackground}"
 											  RightItems="{StaticResource right}"
-											  Margin="12" 
+											  Margin="12"
 											  Height="68">
-									<TextBlock Text="Swipe Left" 
+									<TextBlock Text="Swipe Left"
 											   Margin="12"
-											   HorizontalAlignment="Center" 
-											   VerticalAlignment="Center"/>
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center" />
 								</SwipeControl>
 							</Border>
 						</smtx:XamlDisplay>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
App failing to compile:
> error CS0103: The name '__ResourceOwner_2' does not exist in the current context

## What is the new behavior?
workaround applied to make the app compile.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [x] Tested on Skia.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

## Other information
for context: unoplatform/uno#19745