### PR TITLE
fix(smtx): text-literal indentation

### DIFF
--- a/Uno.Gallery/Views/Styles/XamlDisplay.xaml
+++ b/Uno.Gallery/Views/Styles/XamlDisplay.xaml
@@ -4,6 +4,8 @@
 					xmlns:smtx="using:ShowMeTheXAML"
 					xmlns:local="using:Uno.Gallery">
 
+	<!-- note: The XamlDisplay.Formatter on the is completely replaced by XamlDisplayExtensions attached DPs. -->
+
 	<Style x:Key="ExpanderXamlDisplayStyle"
 		   TargetType="smtx:XamlDisplay">
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1196

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
In ShowMeTheXaml, the indentation level for text literal is higher than it should

## What is the new behavior?
The formatter will now fix the indentation based on the node depth.
ninja-fix: changed indentation from 3spaces to 4spaces

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested in LINQPad