### PR TITLE
fix: Hide Cupertino and Native on Skia targets

### DIFF
--- a/Uno.Gallery/Controls/SamplePageLayout.cs
+++ b/Uno.Gallery/Controls/SamplePageLayout.cs
@@ -51,7 +51,7 @@ namespace Uno.Gallery
 			// Cupertino is disabled as it is not up to date.
 			// new LayoutModeMapping(Design.Cupertino, () => !IsDesignAgnostic, _cupertinoRadioButton, _stickyCupertinoRadioButton, VisualStateCupertino, CupertinoTemplate),
 			new LayoutModeMapping(Design.Agnostic, () => IsDesignAgnostic, null, null, VisualStateAgnostic, DesignAgnosticTemplate),
-#if __IOS__ || __MACOS__ || __ANDROID__
+#if __IOS__ || __MACOS__ || __ANDROID__ && !HAS_UNO_SKIA
 			// native tab is only shown when applicable
 			new LayoutModeMapping(Design.Native, () => !IsDesignAgnostic, _nativeRadioButton, _stickyNativeRadioButton, VisualStateNative, NativeTemplate),
 #else

--- a/Uno.Gallery/Controls/SamplePageLayout.cs
+++ b/Uno.Gallery/Controls/SamplePageLayout.cs
@@ -48,7 +48,8 @@ namespace Uno.Gallery
 		{
 			new LayoutModeMapping(Design.Material, () => !IsDesignAgnostic, _materialRadioButton, _stickyMaterialRadioButton, VisualStateMaterial, MaterialTemplate),
 			new LayoutModeMapping(Design.Fluent, () => !IsDesignAgnostic, _fluentRadioButton, _stickyFluentRadioButton, VisualStateFluent, FluentTemplate),
-			new LayoutModeMapping(Design.Cupertino, () => !IsDesignAgnostic, _cupertinoRadioButton, _stickyCupertinoRadioButton, VisualStateCupertino, CupertinoTemplate),
+			// Cupertino is disabled as it is not up to date.
+			// new LayoutModeMapping(Design.Cupertino, () => !IsDesignAgnostic, _cupertinoRadioButton, _stickyCupertinoRadioButton, VisualStateCupertino, CupertinoTemplate),
 			new LayoutModeMapping(Design.Agnostic, () => IsDesignAgnostic, null, null, VisualStateAgnostic, DesignAgnosticTemplate),
 #if __IOS__ || __MACOS__ || __ANDROID__
 			// native tab is only shown when applicable

--- a/Uno.Gallery/Views/GeneralPages/CupertinoPalettePage.xaml.cs
+++ b/Uno.Gallery/Views/GeneralPages/CupertinoPalettePage.xaml.cs
@@ -17,12 +17,13 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace Uno.Gallery.Views.GeneralPages
 {
+	// Cupertino theme is disabled as it is not actively supported.
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	[SamplePage(SampleCategory.Theming, "Cupertino Palette",
-		SortOrder = 3,
-		Description = "Uno.Cupertino comes with a built-in set of named Color and Brush resources. They are used in most control styles provided by Uno.Cupertino, meaning that you can easily style most controls just by changing a few colors.")]
+	// [SamplePage(SampleCategory.Theming, "Cupertino Palette",
+	// 	SortOrder = 3,
+	// 	Description = "Uno.Cupertino comes with a built-in set of named Color and Brush resources. They are used in most control styles provided by Uno.Cupertino, meaning that you can easily style most controls just by changing a few colors.")]
 	public sealed partial class CupertinoPalettePage : Page
 	{
 		public CupertinoPalettePage()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Gallery/issues/1210

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested on iOS.
- [ ] Tested on Wasm.
- [ ] Tested on Android.
- [ ] Tested on UWP.
- [ ] Tested in both **Light** and **Dark** themes.
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
