### PR TITLE
ci: Fix ios-uitest-run.sh by removing BOM and pinning fb-idb to Python 3.12

### DIFF
--- a/build/scripts/ios-uitest-build.sh
+++ b/build/scripts/ios-uitest-build.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/build/scripts/ios-uitest-run.sh
+++ b/build/scripts/ios-uitest-run.sh
@@ -1,6 +1,10 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 IFS=$'\n\t'
+
+# Ensure this script has no BOM even if it ever gets committed with one again
+# (the BOM only breaks the shebang at exec time, but this is a safety net).
+sed -i '' $'1s/^\xEF\xBB\xBF//' "$0"
 
 export UNO_UITEST_PLATFORM=iOS
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/ios
@@ -9,6 +13,7 @@ export UNO_UITEST_LOGFILE=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/ios/nunit-
 export UNO_UITEST_IOS_PROJECT=$BUILD_SOURCESDIRECTORY/Uno.Gallery
 export UITEST_TEST_TIMEOUT=60m
 
+# Select the simulator to use
 export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-18-4"
 export UNO_UITEST_SIMULATOR_NAME="iPad Pro 13-inch (M4)"
 
@@ -44,19 +49,35 @@ cp "$UITEST_IOSDEVICE_DATA_PATH/../device.plist" $UNO_UITEST_SCREENSHOT_PATH/_lo
 
 echo "Starting simulator: [$UITEST_IOSDEVICE_ID] ($UNO_UITEST_SIMULATOR_VERSION / $UNO_UITEST_SIMULATOR_NAME)"
 
-# check for the presence of idb, and install it if it's not present
+# Check for the presence of idb, and install it if it's not present
+# NOTE: fb-idb currently breaks under Python 3.14 (asyncio get_event_loop change),
+# so we pin fb-idb to Python 3.12 to avoid "There is no current event loop in thread 'MainThread'".
+# Historical context: prior installs referenced an App Center issue/workaround.
+# https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
 export PATH=$PATH:~/.local/bin
 
-if ! command -v idb &> /dev/null
-then
-	echo "Installing idb"
-	brew install pipx
-	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
-	brew tap facebook/fb
-	brew install idb-companion
-	pipx install fb-idb
+if ! command -v idb >/dev/null 2>&1; then
+  echo "Installing idb (fb-idb + idb-companion) pinned to Python 3.12"
+
+  # 1) Make sure we have a usable python3.12, but don't fail if Homebrew linking conflicts
+  if ! command -v python3.12 >/dev/null 2>&1; then
+    # Install, but ignore link-step failure; we'll use the keg path explicitly
+    brew list --versions python@3.12 >/dev/null 2>&1 || brew install python@3.12 || true
+  fi
+  # Prefer an existing python3.12 on PATH; otherwise use the keg path
+  PY312_BIN="$(command -v python3.12 || echo "$(brew --prefix)/opt/python@3.12/bin/python3.12")"
+  export PIPX_DEFAULT_PYTHON="$PY312_BIN"
+  echo "Using Python for pipx: $PIPX_DEFAULT_PYTHON"
+
+  # 2) Install helpers
+  brew list --versions pipx >/dev/null 2>&1 || brew install pipx
+  brew tap facebook/fb >/dev/null 2>&1 || true
+  brew list --versions idb-companion >/dev/null 2>&1 || brew install idb-companion
+
+  # 3) Install fb-idb under Python 3.12
+  pipx install --force fb-idb
 else
-  echo "Using idb from:" `command -v idb`
+  echo "Using idb from: $(command -v idb)"
 fi
 
 echo "Booting the simulator"


### PR DESCRIPTION
## PR Type:

- 🏗️ Build or CI related changes


## Description

Fix ios-uitest-run.sh by removing BOM and pinning fb-idb to Python 3.12 
This was noticed with [canary build errors
](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=179415&view=logs&j=b257d234-dca9-50e9-7ff4-954a28ce7cf0&t=fe9e2dbd-4876-53a0-5018-e399f9ea129b&s=6253236c-e944-5f30-f284-80127adaef74)

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes