### PR TITLE
ci: Fix Play Store publish by using correct applicationId for the default and canary branches

### DIFF
--- a/build/templates/canary-publish/stage-publish-android-canary.yml
+++ b/build/templates/canary-publish/stage-publish-android-canary.yml
@@ -26,8 +26,8 @@
             displayName: 'Play Store Publish'
             inputs:
               serviceConnection: 'Uno Platform Google Play'
-              applicationId: 'uno.platform.gallery.native_canary'
-              bundleFile: '$(Pipeline.Workspace)/drop/publish/uno.platform.gallery.skia_canary-Signed.aab'
+              applicationId: 'uno.platform.gallery_native_canary'
+              bundleFile: '$(Pipeline.Workspace)/drop/publish/uno.platform.gallery_native_canary-Signed.aab'
               track: 'alpha'
 
   - deployment: 'Android_Publish_Skia'

--- a/build/templates/master-publish/stage-publish-android.yml
+++ b/build/templates/master-publish/stage-publish-android.yml
@@ -26,7 +26,7 @@
             displayName: 'Play Store Publish'
             inputs:
               serviceConnection: 'Uno Platform Google Play'
-              applicationId: 'uno.platform.gallery.native'
+              applicationId: 'uno.platform.gallery_native'
               bundleFile: '$(Pipeline.Workspace)/drop/publish/uno.platform.gallery_native-Signed.aab'
               track: 'alpha'
 


### PR DESCRIPTION
## PR Type:

- 🏗️ Build or CI-related changes


## Description 

Fix Play Store publish by using the correct applicationId for the default and canary branches based on https://github.com/unoplatform/Uno.Gallery/commit/65d04dab3a9d59f9e60fc6b80ccc8fde26b9ca82 previous change

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes