### PR TITLE
chore: Remove deprecated Catalyst builds to unblock canary builds

### DIFF
--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -9,7 +9,6 @@
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'==''">
 			net9.0-android;
 			net9.0-ios;
-			net9.0-maccatalyst;
 			net9.0-windows10.0.19041;
 			net9.0-desktop;
 			net9.0-browserwasm;
@@ -32,9 +31,6 @@
 
 		<ApplicationId Condition=" '$(TargetFramework)' == 'net9.0-ios' AND '$(UseNativeRendering)' != 'true' ">com.nventive.uno.gallery</ApplicationId>
 		<ApplicationId Condition=" '$(TargetFramework)' == 'net9.0-ios' AND '$(UseNativeRendering)' == 'true' ">uno.platform.gallery.native</ApplicationId>
-
-		<ApplicationId Condition=" '$(TargetFramework)' == 'net9.0-maccatalyst' AND '$(UseNativeRendering)' != 'true' ">com.nventive.uno.gallery</ApplicationId>
-		<ApplicationId Condition=" '$(TargetFramework)' == 'net9.0-maccatalyst' AND '$(UseNativeRendering)' == 'true' ">uno.platform.gallery.native</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
@@ -59,7 +55,7 @@
 		<IsSkiaWasm Condition="'$(IsSkiaWasm)'==''">false</IsSkiaWasm>
 		<IsSkiaAndroid Condition="'$(UseNativeRendering)'!='true' AND '$(TargetFramework)'=='net9.0-android'">true</IsSkiaAndroid>
 		<IsSkiaAndroid Condition="'$(IsSkiaAndroid)'==''">false</IsSkiaAndroid>
-		<IsSkiaUIKit Condition="'$(UseNativeRendering)'!='true' AND ('$(TargetFramework)'=='net9.0-ios' OR '$(TargetFramework)'=='net9.0-maccatalyst')">true</IsSkiaUIKit>
+		<IsSkiaUIKit Condition="'$(UseNativeRendering)'!='true' AND '$(TargetFramework)'=='net9.0-ios'">true</IsSkiaUIKit>
 		<IsSkiaUIKit Condition="'$(IsSkiaUIKit)'==''">false</IsSkiaUIKit>
 		<UnoFeatures>
 			Material;
@@ -148,22 +144,6 @@
 
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(Configuration)'=='Release' and '$(System_PullRequest_IsFork)'!='True' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">
-		<MtouchUseLlvm>true</MtouchUseLlvm>
-		<CodeSigningKey>Apple Distribution: Uno Platform Inc. (PD74CHS9Z5)</CodeSigningKey>
-		<PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-		<CreatePackage>true</CreatePackage>
-		<EnablePackageSigning>true</EnablePackageSigning>
-		<EnableCodeSigning>true</EnableCodeSigning>
-		<CodeSignEntitlements>MacCatalyst\Entitlements.plist</CodeSignEntitlements>
-
-		<CodesignProvision>Uno Gallery Native (Catalyst)</CodesignProvision>
-		<CodesignProvision Condition="$(BUILD_SOURCEBRANCH.StartsWith('refs/heads/canaries'))">Uno Gallery Native Canary (Catalyst)</CodesignProvision>
-
-		<CodesignProvision Condition=" '$(UseNativeRendering)' != 'true' ">Uno Gallery (Catalyst)</CodesignProvision>
-		<CodesignProvision Condition=" '$(UseNativeRendering)' != 'true' AND $(BUILD_SOURCEBRANCH.StartsWith('refs/heads/canaries'))">Uno Gallery Canary (Catalyst)</CodesignProvision>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)'=='Release' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android'">
 		<RunAOTCompilation>true</RunAOTCompilation>
 	</PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,25 +136,11 @@ stages:
           BuildCommand: publish
           UseNativeRendering: true
           VariantName: Native
-        Catalyst:
-          BuildTargetFramework: net9.0-maccatalyst
-          ArtifactName: Catalyst
-          ApplicationBuildNumberOffset: 50
-          BuildCommand: build
-          UseNativeRendering: true
-          VariantName: Native
         iOS_Skia:
           BuildTargetFramework: net9.0-ios
           ArtifactName: iOS-mobile
           ApplicationBuildNumberOffset: 50
           BuildCommand: publish
-          UseNativeRendering: false
-          VariantName: Skia
-        Catalyst_Skia:
-          BuildTargetFramework: net9.0-maccatalyst
-          ArtifactName: Catalyst
-          ApplicationBuildNumberOffset: 50
-          BuildCommand: build
           UseNativeRendering: false
           VariantName: Skia
     pool:
@@ -191,18 +177,6 @@ stages:
       displayName: 'Install Apple Provisioning Profile'
       inputs:
         provisioningProfileLocation: 'secureFiles'
-        provProfileSecureFile: Uno_Gallery_Catalyst.provisionprofile
-  
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install Apple Provisioning Profile'
-      inputs:
-        provisioningProfileLocation: 'secureFiles'
-        provProfileSecureFile: Uno_Gallery_Canary_Catalyst.provisionprofile
-  
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install Apple Provisioning Profile'
-      inputs:
-        provisioningProfileLocation: 'secureFiles'
         provProfileSecureFile: Uno_Gallery_iOS.mobileprovision
   
     - task: InstallAppleProvisioningProfile@1
@@ -215,18 +189,6 @@ stages:
     # Gallery Native
     #
       
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install Apple Provisioning Profile'
-      inputs:
-        provisioningProfileLocation: 'secureFiles'
-        provProfileSecureFile: Uno_Gallery_Native_Catalyst.provisionprofile
-  
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install Apple Provisioning Profile'
-      inputs:
-        provisioningProfileLocation: 'secureFiles'
-        provProfileSecureFile: Uno_Gallery_Native_Canary_Catalyst.provisionprofile
-  
     - task: InstallAppleProvisioningProfile@1
       displayName: 'Install Apple Provisioning Profile'
       inputs:
@@ -292,11 +254,9 @@ stages:
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries/dev') }}:
   - template: build/templates/canary-publish/stage-publish-wasm-canary.yml
   - template: build/templates/canary-publish/stage-publish-ios-canary.yml
-  - template: build/templates/canary-publish/stage-publish-catalyst-canary.yml
   - template: build/templates/canary-publish/stage-publish-android-canary.yml
 
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/master') }}:
   - template: build/templates/master-publish/stage-publish-wasm.yml
   - template: build/templates/master-publish/stage-publish-ios.yml
-  - template: build/templates/master-publish/stage-publish-catalyst.yml
   - template: build/templates/master-publish/stage-publish-android.yml


### PR DESCRIPTION
**GitHub Issue:** partial https://github.com/unoplatform/uno-private/issues/1413

## PR Type:

- 🏗️ Build or CI related changes


## Description

Remove deprecated Catalyst builds to unblock canary builds ([Related discussion](https://teams.microsoft.com/l/message/19:c857d68e0be84cfba6ff9a8611200680@thread.tacv2/1765412592815?tenantId=a297d6c0-b635-41a3-b1e3-558efe71e413&groupId=f55cdec8-036b-4efa-8e1a-c4129ba9bf12&parentMessageId=1765412592815&teamName=Uno%20Platform&channelName=Collab%20Lounge&createdTime=1765412592815))

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
