### PR TITLE
ci: cleanup unused image dependencies

### DIFF
--- a/build/stage-build-wasm.yml
+++ b/build/stage-build-wasm.yml
@@ -5,6 +5,8 @@
 
 - template: templates/canary-updater.yml
 
+- template: templates/host-cleanup-linux.yml
+
 - bash: |
     dotnet publish Uno.Gallery/Uno.Gallery.csproj -c Release -f net9.0-browserwasm -p:UseNativeRendering=$(UseNativeRendering) -p:InformationalVersion=$(NBGV_InformationalVersion) -o "$(Agent.TempDirectory)/wasm-publish" -bl:$(Build.ArtifactStagingDirectory)/wasm-publish.binlog
   displayName: 'Builds Wasm $(ArtifactName)'

--- a/build/stage-uitests-android.yml
+++ b/build/stage-uitests-android.yml
@@ -21,6 +21,8 @@
 
   - template: templates/canary-updater.yml
 
+  - template: templates/host-cleanup-linux.yml
+
   - bash: |
       chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
       $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh

--- a/build/stage-uitests-wasm.yml
+++ b/build/stage-uitests-wasm.yml
@@ -19,6 +19,8 @@
 
   - template: templates/canary-updater.yml
 
+  - template: templates/host-cleanup-linux.yml
+
   - bash: |
       chmod +x build/scripts/wasm-uitest-build.sh
       build/scripts/wasm-uitest-build.sh
@@ -58,6 +60,8 @@
     parameters:
       installJava: false
       installWorkloads: false
+
+  - template: templates/host-cleanup-linux.yml
 
   - bash: |
       export UNO_UITEST_WASM_OUTPUT_PATH=$(Pipeline.Workspace)/Wasm_UITest

--- a/build/templates/host-cleanup-linux.yml
+++ b/build/templates/host-cleanup-linux.yml
@@ -1,0 +1,23 @@
+steps:
+- bash: |
+    # This list is based on what the base image contains and
+    # may need to be adjusted as new software gets installed.
+    # Use the `du` command below to determine what can be
+    # uninstalled.
+    
+    rm -fR ~/.cargo
+    rm -fR ~/.rustup
+    rm -fR ~/.dotnet
+    sudo rm -fR /usr/share/swift
+    sudo rm -fR /opt/microsoft/msedge
+    sudo rm -fR /usr/local/.ghcup
+    sudo rm -fR /usr/lib/mono
+    sudo snap remove lxd
+    sudo snap remove core20
+    sudo apt remove snapd
+
+    df -h
+    # du -h -d 3 /
+
+  displayName: 'Cleanup unused image dependencies (Linux)'
+  condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION
This pull request introduces a new build template to perform cleanup of unused dependencies on Linux build agents, and integrates this cleanup step into several build and test pipelines. This change aims to free up disk space during CI runs, potentially improving build reliability and performance.

Integration of Linux cleanup step:

* Added a new template `templates/host-cleanup-linux.yml` that removes unused dependencies and software from Linux build agents to reclaim disk space.

Pipeline updates to include cleanup:

* Included the `host-cleanup-linux.yml` template in the following build pipelines:
  - `build/stage-build-wasm.yml`
  - `build/stage-uitests-android.yml`
  - `build/stage-uitests-wasm.yml` [[1]](diffhunk://#diff-97cf78c7078aabc9989794a3815c490f9cb3072ac0d90c10a28624f8b7191cf7R22-R23) [[2]](diffhunk://#diff-97cf78c7078aabc9989794a3815c490f9cb3072ac0d90c10a28624f8b7191cf7R64-R65)