### PR TITLE
ci: install dotnet before canary updater

### DIFF
--- a/build/stage-build-windows.yml
+++ b/build/stage-build-windows.yml
@@ -1,13 +1,13 @@
 steps:
-- template: templates/canary-updater.yml
-- template: templates/gitversion.yml
-
 - task: UseDotNet@2
   displayName: 'Use .NET'
   inputs:
     packageType: 'sdk'
     version: '9.0.300'
     includePreviewVersions: true
+
+- template: templates/canary-updater.yml
+- template: templates/gitversion.yml
 
 - script: |
     cd $(build.sourcesdirectory)/Uno.Gallery

--- a/build/stage-uitests-android.yml
+++ b/build/stage-uitests-android.yml
@@ -73,6 +73,14 @@
   - download: current
     artifact: Android_UITest
 
+  - task: UseDotNet@2
+    displayName: 'Ensure .NET SDK 9.0.300 for canary'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
+    inputs:
+      packageType: 'sdk'
+      version: '9.0.300'
+      includePreviewVersions: true
+
   - template: templates/canary-updater.yml
 
   - task: PowerShell@2

--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -1,5 +1,18 @@
 
+parameters:
+  DotNetVersion: '9.0.300'
+  EnsureDotNet: true
+
 steps:
+- ${{ if eq(parameters.EnsureDotNet, 'true') }}:
+  - task: UseDotNet@2
+    displayName: 'Ensure .NET SDK ${{ parameters.DotNetVersion }} for canary'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
+    inputs:
+      packageType: 'sdk'
+      version: ${{ parameters.DotNetVersion }}
+      includePreviewVersions: true
+
   - task: unoplatformCanaryUpdater@1
     displayName: 'Canary Update (dev)'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries/dev')


### PR DESCRIPTION
## Summary
- Install the configured .NET SDK inside the shared canary template so Uno.NuGet.Updater never runs without DOTNET_ROOT
- Reorder windows canary stage to invoke UseDotNet before the updater
- Add a fallback UseDotNet step for macOS UITest jobs when running canaries

## Context
- Azure DevOps/macOS hosted agents removed DOTNET_ROOT on Jan 12, so Uno.NuGet.Updater failed when it ran before UseDotNet, see:
	- actions/runner-images#13470
	- actions/runner-images#13392
