### PR TITLE
chore: Introductory support for NativeAOT builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
 		<PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Xamarin.UITest" Version="4.4.1" />
 
-		<PackageVersion Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0015" />
-		<PackageVersion Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0015" />
+		<PackageVersion Include="Uno.ShowMeTheXAML" Version="2.0.0-dev0026" />
+		<PackageVersion Include="Uno.ShowMeTheXAML.MSBuild" Version="2.0.0-dev0026" />
 
 		<PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200" />
 		<PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.200" />
@@ -32,6 +32,8 @@
 		<PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
 		<PackageVersion Include="Microsoft.TypeScript.Compiler" Version="3.1.5" />
 		<PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.6.4" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1-RTM" />
 		<PackageVersion Include="nventive.Nimue.Application.Packaging" Version="0.1.0-alpha.58" />
 		<PackageVersion Include="Xamarin.TestCloud.Agent" Version="0.23.2" />
 	</ItemGroup>

--- a/Uno.Gallery/App.xaml.cs
+++ b/Uno.Gallery/App.xaml.cs
@@ -28,6 +28,8 @@ namespace Uno.Gallery
 	/// </summary>
 	public partial class App : Application
 	{
+		private readonly bool _exitAfterLaunching;
+
 		public static App Instance { get; private set; }
 
 		public Window MainWindow { get; private set; }
@@ -37,7 +39,13 @@ namespace Uno.Gallery
 		/// executed, and as such is the logical equivalent of main() or WinMain().
 		/// </summary>
 		public App()
+			: this(false)
 		{
+		}
+
+		public App(bool exitAfterLaunching)
+		{
+			_exitAfterLaunching = exitAfterLaunching;
 			Instance = this;
 
 			ConfigureFeatureFlags();
@@ -71,6 +79,11 @@ namespace Uno.Gallery
 
 			this.Log().Debug("Launched app.");
 			OnLaunchedOrActivated();
+
+			if (_exitAfterLaunching)
+			{
+				Exit();
+			}
 		}
 
 		private void OnLaunchedOrActivated()
@@ -486,7 +499,11 @@ namespace Uno.Gallery
 
 		private void ConfigureXamlDisplay()
 		{
+#if WINDOWS
 			XamlDisplay.Init(GetType().Assembly);
+#else   // !WINDOWS
+			XamlDictionary.Init();
+#endif  // WINDOWS
 		}
 
 		private void ConfigureFeatureFlags()

--- a/Uno.Gallery/Entities/Data/DividerItem.cs
+++ b/Uno.Gallery/Entities/Data/DividerItem.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace Uno.Gallery.Entities.Data
 {
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class DividerItem
 	{
 		public DividerItem(int i)

--- a/Uno.Gallery/Entities/Data/Folder.cs
+++ b/Uno.Gallery/Entities/Data/Folder.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 
 namespace Uno.Gallery.Entities.Data
 {
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class Folder
 	{
 		public Folder(string name, int itemCount, string description)

--- a/Uno.Gallery/Entities/Data/Plant.cs
+++ b/Uno.Gallery/Entities/Data/Plant.cs
@@ -5,6 +5,7 @@ using static Uno.Gallery.Entities.Data.Plant;
 
 namespace Uno.Gallery.Entities.Data;
 
+[Microsoft.UI.Xaml.Data.Bindable]
 public class Plant : IComparable
 {
 	public Plant(

--- a/Uno.Gallery/Entities/Data/Record.cs
+++ b/Uno.Gallery/Entities/Data/Record.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace Uno.Gallery.Entities.Data
 {
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class Record
 	{
 		public Record(string compositionName, string artistName, string color)

--- a/Uno.Gallery/Entities/Data/TestCollections.cs
+++ b/Uno.Gallery/Entities/Data/TestCollections.cs
@@ -42,6 +42,7 @@ namespace Uno.Gallery.Entities.Data
 			}
 		}
 
+		[Microsoft.UI.Xaml.Data.Bindable]
 		public class SelectableData : InpcObject
 		{
 			public int Index { get => GetProperty<int>(); set => SetProperty(value); }
@@ -51,6 +52,7 @@ namespace Uno.Gallery.Entities.Data
 			public override string ToString() => $"Item #{Index}";
 		}
 
+		[Microsoft.UI.Xaml.Data.Bindable]
 		public class InpcObject : INotifyPropertyChanged
 		{
 			public event PropertyChangedEventHandler PropertyChanged;

--- a/Uno.Gallery/Entities/Data/TreeItem.cs
+++ b/Uno.Gallery/Entities/Data/TreeItem.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 
 namespace Uno.Gallery.Entities.Data
 {
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class TreeItem
 	{
 		public TreeItem(string name)

--- a/Uno.Gallery/Entities/Sample.cs
+++ b/Uno.Gallery/Entities/Sample.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,7 +14,11 @@ namespace Uno.Gallery
 	[Bindable]
 	public class Sample
 	{
-		public Sample(SamplePageAttribute attribute, Type viewType)
+		internal const DynamicallyAccessedMemberTypes ViewRequirements =
+			  DynamicallyAccessedMemberTypes.PublicConstructors
+			| DynamicallyAccessedMemberTypes.PublicProperties;
+
+		public Sample(SamplePageAttribute attribute, [DynamicallyAccessedMembers(ViewRequirements)] Type viewType)
 		{
 			Category = attribute.Category;
 			Title = attribute.Title;
@@ -30,7 +35,7 @@ namespace Uno.Gallery
 			SortOrder = attribute.SortOrder;
 		}
 
-		private object CreateData(Type dataType)
+		private object? CreateData([DynamicallyAccessedMembers(ViewRequirements)] Type? dataType)
 		{
 			if (dataType == null) return null;
 
@@ -55,12 +60,13 @@ namespace Uno.Gallery
 
 		public Uri DocumentationLink { get; }
 
-		public object Data { get; }
+		public object? Data { get; }
 
 		public int? SortOrder { get; }
 
 		public SourceSdk Source { get; }
 
+		[DynamicallyAccessedMembers(ViewRequirements)]
 		public Type ViewType { get; }
 	}
 }

--- a/Uno.Gallery/Entities/SamplePageAttribute.cs
+++ b/Uno.Gallery/Entities/SamplePageAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
@@ -30,6 +31,7 @@ namespace Uno.Gallery
 
 		public string DocumentationLink { get; set; }
 
+		[DynamicallyAccessedMembers(Sample.ViewRequirements)]
 		public Type DataType { get; set; }
 
 		public SourceSdk Source { get; }

--- a/Uno.Gallery/Extensions/ClipboardExtensions.cs
+++ b/Uno.Gallery/Extensions/ClipboardExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Uno.Extensions;
 using Uno.Logging;
@@ -25,7 +26,12 @@ namespace Uno.Gallery
 
 		#region Property: CopyTrigger
 
-		public static DependencyProperty CopyTriggerProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty CopyTriggerProperty
+		{
+			[DynamicDependency(nameof(GetCopyTrigger))]
+			[DynamicDependency(nameof(SetCopyTrigger))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"CopyTrigger",
 			typeof(CopyTrigger),
 			typeof(ClipboardExtensions),
@@ -37,7 +43,12 @@ namespace Uno.Gallery
 		#endregion
 		#region Property: CopyContent
 
-		public static DependencyProperty CopyContentProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty CopyContentProperty
+		{
+			[DynamicDependency(nameof(GetCopyContent))]
+			[DynamicDependency(nameof(SetCopyContent))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"CopyContent",
 			typeof(string),
 			typeof(ClipboardExtensions),
@@ -49,7 +60,12 @@ namespace Uno.Gallery
 		#endregion
 		#region Property: CopySubscription (private)
 
-		private static DependencyProperty CopySubscriptionProperty { get; } = DependencyProperty.RegisterAttached(
+		private static DependencyProperty CopySubscriptionProperty
+		{
+			[DynamicDependency(nameof(GetCopySubscription))]
+			[DynamicDependency(nameof(SetCopySubscription))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"CopySubscription",
 			typeof(IDisposable),
 			typeof(ClipboardExtensions),

--- a/Uno.Gallery/Extensions/XamlDisplayExtensions.cs
+++ b/Uno.Gallery/Extensions/XamlDisplayExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -28,7 +29,12 @@ namespace ShowMeTheXAML
 
 		#region Property: Header
 
-		public static DependencyProperty HeaderProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty HeaderProperty
+		{
+			[DynamicDependency(nameof(GetHeader))]
+			[DynamicDependency(nameof(SetHeader))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"Header",
 			typeof(string),
 			typeof(XamlDisplayExtensions),
@@ -40,7 +46,12 @@ namespace ShowMeTheXAML
 		#endregion
 		#region Property: Description
 
-		public static DependencyProperty DescriptionProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty DescriptionProperty
+		{
+			[DynamicDependency(nameof(GetDescription))]
+			[DynamicDependency(nameof(SetDescription))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"Description",
 			typeof(string),
 			typeof(XamlDisplayExtensions),
@@ -49,7 +60,12 @@ namespace ShowMeTheXAML
 		public static string GetDescription(XamlDisplay obj) => (string)obj.GetValue(DescriptionProperty);
 		public static void SetDescription(XamlDisplay obj, string value) => obj.SetValue(DescriptionProperty, value);
 
-		public static DependencyProperty DocumentationLinkProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty DocumentationLinkProperty
+		{
+			[DynamicDependency(nameof(GetDocumentationLink))]
+			[DynamicDependency(nameof(SetDocumentationLink))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"DocumentationLink",
 			typeof(string),
 			typeof(XamlDisplayExtensions),
@@ -61,7 +77,12 @@ namespace ShowMeTheXAML
 		#endregion
 		#region Property: IgnorePath
 
-		public static DependencyProperty IgnorePathProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty IgnorePathProperty
+		{
+			[DynamicDependency(nameof(GetIgnorePath))]
+			[DynamicDependency(nameof(SetIgnorePath))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"IgnorePath",
 			typeof(string),
 			typeof(XamlDisplayExtensions),
@@ -73,7 +94,12 @@ namespace ShowMeTheXAML
 		#endregion
 		#region Property: PrettyXaml
 
-		public static DependencyProperty PrettyXamlProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty PrettyXamlProperty
+		{
+			[DynamicDependency(nameof(GetPrettyXaml))]
+			[DynamicDependency(nameof(SetPrettyXaml))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"PrettyXaml",
 			typeof(string),
 			typeof(XamlDisplayExtensions),
@@ -86,7 +112,12 @@ namespace ShowMeTheXAML
 
 		#region Property: ShowXaml
 
-		public static DependencyProperty ShowXamlProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty ShowXamlProperty
+		{
+			[DynamicDependency(nameof(GetShowXaml))]
+			[DynamicDependency(nameof(SetShowXaml))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"ShowXaml",
 			typeof(bool),
 			typeof(XamlDisplayExtensions),
@@ -99,7 +130,12 @@ namespace ShowMeTheXAML
 
 		#region Property: IsXamlDirty
 
-		public static DependencyProperty IsXamlDirtyProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsXamlDirtyProperty
+		{
+			[DynamicDependency(nameof(GetIsXamlDirty))]
+			[DynamicDependency(nameof(SetIsXamlDirty))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"IsXamlDirty",
 			typeof(bool),
 			typeof(XamlDisplayExtensions),
@@ -111,7 +147,12 @@ namespace ShowMeTheXAML
 		#endregion
 
 		#region Property: Options
-		public static DependencyProperty OptionsProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty OptionsProperty
+		{
+			[DynamicDependency(nameof(GetOptions))]
+			[DynamicDependency(nameof(SetOptions))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"Options",
 			typeof(object),
 			typeof(XamlDisplayExtensions),

--- a/Uno.Gallery/Platforms/Desktop/Program.cs
+++ b/Uno.Gallery/Platforms/Desktop/Program.cs
@@ -8,10 +8,12 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        var exit = args.Any(a => a == "--exit");
+
         App.InitializeLogging();
 
         var host = UnoPlatformHostBuilder.Create()
-            .App(() => new App())
+            .App(() => new App(exit))
             .UseX11()
             .UseLinuxFrameBuffer()
             .UseMacOS()

--- a/Uno.Gallery/Platforms/iOS/Info.plist
+++ b/Uno.Gallery/Platforms/iOS/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>CFBundleDisplayName</key>
-		<string>Uno.Gallery</string>
 		<key>CFBundleShortVersionString</key>
 		<string>1.0</string>
 		<key>CFBundleVersion</key>

--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -14,6 +14,11 @@
 			net10.0-browserwasm;
 		</TargetFrameworks>
 
+		<PublishAot Condition=" '$(PublishAot)' == '' And '$(SkiaPublishAot)' == 'true' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' ">true</PublishAot>
+		<PublishAot Condition=" '$(PublishAot)' == '' And '$(SkiaPublishAot)' == 'true' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' ">true</PublishAot>
+		<PublishAot Condition=" '$(PublishAot)' == '' And '$(SkiaPublishAot)' != '' ">$(SkiaPublishAot)</PublishAot>
+		<IsAotCompatible Condition=" '$(IsAotCompatible)' == '' And '$(PublishAot)' == 'true' ">true</IsAotCompatible>
+
 		<!--
 		Uncomment to use Native rendering for iOS/Android/Wasm
 		<UseNativeRendering>true</UseNativeRendering>
@@ -22,7 +27,9 @@
 		<OutputType>Exe</OutputType>
 		<UnoSingleProject>true</UnoSingleProject>
 		<!-- Display name -->
-		<ApplicationTitle>Gallery</ApplicationTitle>
+		<ApplicationTitle Condition=" '$(ApplicationTitle)' == '' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' ">Uno.Gallery</ApplicationTitle>
+		<ApplicationTitle Condition=" '$(ApplicationTitle)' == '' ">Gallery</ApplicationTitle>
+		<ApplicationTitle>$(ApplicationTitle)$(ApplicationTitleVendorSuffix)</ApplicationTitle>
 		<!-- App Identifier -->
 		<ApplicationId>uno.platform.gallery</ApplicationId>
 
@@ -31,6 +38,8 @@
 
 		<ApplicationId Condition=" '$(TargetFramework)' == 'net10.0-ios' AND '$(UseNativeRendering)' != 'true' ">com.nventive.uno.gallery</ApplicationId>
 		<ApplicationId Condition=" '$(TargetFramework)' == 'net10.0-ios' AND '$(UseNativeRendering)' == 'true' ">uno.platform.gallery.native</ApplicationId>
+
+		<ApplicationId Condition=" '$(ApplicationIdVendorSuffix)' != '' ">$(ApplicationId)$(ApplicationIdVendorSuffix)</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
@@ -144,10 +153,6 @@
 
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(Configuration)'=='Release' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android'">
-		<RunAOTCompilation>true</RunAOTCompilation>
-	</PropertyGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)'!='net10.0-windows10.0.19041'">
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" />
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" />
@@ -158,6 +163,8 @@
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" />
 		<PackageReference Include="VideoLAN.LibVLC.Windows" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="nventive.Nimue.Application.Packaging">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Uno.Gallery/ViewModels/ViewModelBase.cs
+++ b/Uno.Gallery/ViewModels/ViewModelBase.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 
 namespace Uno.Gallery.ViewModels
 {
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public abstract class ViewModelBase : INotifyPropertyChanged
 	{
 		public event PropertyChangedEventHandler PropertyChanged;

--- a/Uno.Gallery/Views/SamplePages/AccelerometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AccelerometerSamplePage.xaml.cs
@@ -32,6 +32,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class AccelerometerSamplePageViewModel: INotifyPropertyChanged
 	{
 		private const string _startObservingContent = "Start observing accelerometer reading changes";

--- a/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/AutoSuggestBoxSamplePage.xaml.cs
@@ -94,6 +94,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class AutoSuggestBoxSamplePageViewModel : ViewModelBase
 	{
 		public string SelectedString { get => GetProperty<string>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/BarometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/BarometerSamplePage.xaml.cs
@@ -35,6 +35,7 @@ namespace Uno.Gallery.Views.Samples
 	}
 }
 
+[Microsoft.UI.Xaml.Data.Bindable]
 public class BarometerSamplePageViewModel : ViewModelBase
 {
 	private const string _startObservingContent = "Start observing barometer reading changes";

--- a/Uno.Gallery/Views/SamplePages/BindingSamplePage.xaml
+++ b/Uno.Gallery/Views/SamplePages/BindingSamplePage.xaml
@@ -20,6 +20,7 @@
 							<StackPanel.DataContext>
 								<samples:BindingSamplePageViewModel />
 								<!--
+[Microsoft.UI.Xaml.Data.Bindable]
 public class BindingSamplePageViewModel : INotifyPropertyChanged
 {
 	public event PropertyChangedEventHandler PropertyChanged;

--- a/Uno.Gallery/Views/SamplePages/BindingSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/BindingSamplePage.xaml.cs
@@ -26,6 +26,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class BindingSamplePageViewModel : INotifyPropertyChanged
 	{
 		public event PropertyChangedEventHandler PropertyChanged;

--- a/Uno.Gallery/Views/SamplePages/BreadcrumbBarSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/BreadcrumbBarSamplePage.xaml.cs
@@ -47,6 +47,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class BreadcrumbBarSamplePageViewModel : ViewModelBase
 	{
 		public string[] Items { get => GetProperty<string[]>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/ClipboardSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/ClipboardSamplePage.xaml.cs
@@ -240,6 +240,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class ClipboardSamplePageViewModel : INotifyPropertyChanged
 	{
 		public event PropertyChangedEventHandler PropertyChanged;

--- a/Uno.Gallery/Views/SamplePages/ColorPickerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/ColorPickerSamplePage.xaml.cs
@@ -26,6 +26,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class ColorPickerSamplePageViewModel : ViewModelBase
 	{
 		public bool IsColorSliderVisible { get => GetProperty<bool>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/ComboBoxSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/ComboBoxSamplePage.xaml.cs
@@ -25,6 +25,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class ComboBoxSampleViewModel : ViewModelBase
 	{
 		public string[] Items { get => GetProperty<string[]>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/DataGridSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/DataGridSamplePage.xaml.cs
@@ -149,6 +149,7 @@ public sealed partial class DataGridSamplePage : Page
 	}
 }
 
+[Microsoft.UI.Xaml.Data.Bindable]
 public class DataGridSamplePageViewModel : ViewModelBase
 {
 	public int ColumnHeaderHeight { get => GetProperty<int>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/EmailManagerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/EmailManagerSamplePage.xaml.cs
@@ -20,6 +20,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class EmailManagerSamplePageViewModel : ViewModelBase
 	{
 		// EmailManager only supports the ShowComposeNewEmailInternalAsync, with the properties: To (only addresses, without names), CC (only addresses, without names), BCC (only addresses, without names), Subject, Body

--- a/Uno.Gallery/Views/SamplePages/GamepadSamplePage.xaml
+++ b/Uno.Gallery/Views/SamplePages/GamepadSamplePage.xaml
@@ -88,6 +88,7 @@ private async void UpdateGamepads()
 }
 
 
+[Microsoft.UI.Xaml.Data.Bindable]
 public class GamepadViewModel : ViewModelBase
 {
 	public GamepadViewModel(Gamepad gamepad)

--- a/Uno.Gallery/Views/SamplePages/GamepadSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/GamepadSamplePage.xaml.cs
@@ -34,6 +34,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class GamepadSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing gamepad changes";
@@ -121,6 +122,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class GamepadViewModel : ViewModelBase
 	{
 		public GamepadViewModel(Gamepad gamepad)

--- a/Uno.Gallery/Views/SamplePages/GeolocatorSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/GeolocatorSamplePage.xaml.cs
@@ -35,6 +35,7 @@ namespace Uno.Gallery.Views.Samples
         }
     }
 
+    [Microsoft.UI.Xaml.Data.Bindable]
     public class GeolocatorSamplePageViewModel : INotifyPropertyChanged
     {
         private Geolocator _geolocator;

--- a/Uno.Gallery/Views/SamplePages/GridViewSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/GridViewSamplePage.xaml.cs
@@ -24,6 +24,8 @@ namespace Uno.Gallery.Views.Samples
 			this.InitializeComponent();
 		}
 	}
+
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class GridViewSampleViewModel : ViewModelBase
 	{
 		public char[] Items { get => GetProperty<char[]>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/GyrometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/GyrometerSamplePage.xaml.cs
@@ -37,6 +37,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class GyrometerSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing gyrometer reading changes";

--- a/Uno.Gallery/Views/SamplePages/HingeAngleSensorPage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/HingeAngleSensorPage.xaml.cs
@@ -32,6 +32,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class HingeAngleSensorSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing hinge angle sensor reading changes";

--- a/Uno.Gallery/Views/SamplePages/InfoBadgeSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/InfoBadgeSamplePage.xaml.cs
@@ -17,6 +17,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class InfoBadgeSamplePageViewModel : ViewModelBase
 	{
 		public bool AreBadgesVisible { get => GetProperty<bool>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/LampSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/LampSamplePage.xaml.cs
@@ -34,6 +34,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class LampSamplePageViewModel : ViewModelBase, IDisposable
 	{
 		private const string _enable = "Enable flashlight";

--- a/Uno.Gallery/Views/SamplePages/LauncherSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/LauncherSamplePage.xaml.cs
@@ -34,6 +34,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class LauncherSamplePageViewModel : ViewModelBase
 	{
 		public string SettingsButtonContent { get => GetProperty<string>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/LightSensorSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/LightSensorSamplePage.xaml.cs
@@ -31,6 +31,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class LightSensorSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing light sensor reading changes";

--- a/Uno.Gallery/Views/SamplePages/MagnetometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/MagnetometerSamplePage.xaml.cs
@@ -32,6 +32,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class MagnetometerSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing magnetometer reading changes";

--- a/Uno.Gallery/Views/SamplePages/NetworkInformationSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/NetworkInformationSamplePage.xaml.cs
@@ -40,6 +40,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class NetworkInformationSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing connectivity changes";

--- a/Uno.Gallery/Views/SamplePages/PedometerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/PedometerSamplePage.xaml.cs
@@ -36,6 +36,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class PedometerSamplePageViewModel : ViewModelBase
 	{
 		private const string StartObservingPedometerLabel = "Start observing pedometer reading changes";

--- a/Uno.Gallery/Views/SamplePages/PhoneCallManagerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/PhoneCallManagerSamplePage.xaml.cs
@@ -40,6 +40,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class PhoneCallManagerSamplePageViewModel : ViewModelBase
 	{
 		public bool IsSettingsUISupported { get; set; }

--- a/Uno.Gallery/Views/SamplePages/PowerManagerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/PowerManagerSamplePage.xaml.cs
@@ -35,6 +35,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class PowerManagerSamplePageViewModel : INotifyPropertyChanged
 	{
 		private bool _monitoringPowerStatus;

--- a/Uno.Gallery/Views/SamplePages/RatingControlSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/RatingControlSamplePage.xaml.cs
@@ -16,6 +16,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class RatingControlSamplePageViewModel : ViewModelBase
 	{
 		public int MaxRating { get => GetProperty<int>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/ShadowContainerSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/ShadowContainerSamplePage.xaml.cs
@@ -69,6 +69,7 @@ namespace Uno.Gallery.Views.SamplePages
 			_shadows.RemoveAt(_shadows.Count - 1);
 		}
 
+		[Microsoft.UI.Xaml.Data.Bindable]
 		public class ShadowContainerViewModel : ViewModelBase
 		{
 			public ObservableCollection<string> CbbItems { get; } = new ObservableCollection<string>

--- a/Uno.Gallery/Views/SamplePages/SimpleOrientationSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/SimpleOrientationSamplePage.xaml.cs
@@ -36,6 +36,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class SimpleOrientationSamplePageViewModel : ViewModelBase
 	{
 		private const string _startObservingContent = "Start observing orientation changes";

--- a/Uno.Gallery/Views/SamplePages/TabBarSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/TabBarSamplePage.xaml.cs
@@ -47,6 +47,7 @@ namespace Uno.Gallery.Views.SamplePages
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class TabBarViewModel : ViewModelBase
 	{
 		public List<string> Items { get; }

--- a/Uno.Gallery/Views/SamplePages/TreeViewSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/TreeViewSamplePage.xaml.cs
@@ -17,6 +17,7 @@ namespace Uno.Gallery.Views.Samples
 		}
 	}
 
+	[Microsoft.UI.Xaml.Data.Bindable]
 	public class TreeViewSamplePageViewModel : ViewModelBase
 	{
 		public ObservableCollection<TreeItem> Items { get => GetProperty<ObservableCollection<TreeItem>>(); set => SetProperty(value); }

--- a/Uno.Gallery/Views/SamplePages/VariableSizedWrapGridSamplePage.xaml.cs
+++ b/Uno.Gallery/Views/SamplePages/VariableSizedWrapGridSamplePage.xaml.cs
@@ -12,6 +12,7 @@ namespace Uno.Gallery.Views.Samples
 			DataContext = new VariableSizedWrapGridViewModel();
 		}
 
+		[Microsoft.UI.Xaml.Data.Bindable]
 		public class VariableSizedWrapGridViewModel : INotifyPropertyChanged
 		{
 			public event PropertyChangedEventHandler PropertyChanged;

--- a/build/scripts/android-uitest-build.sh
+++ b/build/scripts/android-uitest-build.sh
@@ -34,8 +34,27 @@ then
 	echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'platforms;android-35' | tr '\r' '\n' | uniq
 	echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'platforms;android-36' | tr '\r' '\n' | uniq
 	echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'extras;android;m2repository' | tr '\r' '\n' | uniq
+
+	if [ "${NAOT:-0}" = "1" ]; then
+		# NDK r27+ is required for NativeAOT builds
+		echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'ndk;28.2.13676358' | tr '\r' '\n' | uniq
+	fi
 fi
 
 # Build the sample, while the emulator is starting
 cd $UNO_UITEST_ANDROID_PROJECT
-dotnet publish -f net10.0-android -p:TargetFrameworkOverride=net10.0-android -p:UseNativeRendering=true -c Release /p:AndroidPackageFormat=apk /p:RuntimeIdentifier=android-x64 /p:IsUiAutomationMappingEnabled=true /p:AndroidUseSharedRuntime=false /p:AndroidUseAssemblyStore=false /p:RunAOTCompilation=false /p:PublishTrimmed=false /p:AndroidStripILAfterAOT=false -bl:"$BUILD_ARTIFACTSTAGINGDIRECTORY/android-app.binlog"
+
+publish_extra=(-c Release)
+BINLOG_SUFFIX=""
+if [ "${NAOT:-0}" = "1" ]; then
+	# Build the sample with NativeAOT enabled
+	publish_extra+=("-m:1" "-p:SkiaPublishAot=true" "-p:ApplicationTitleVendorSuffix= (NAOT)" "-p:ApplicationIdVendorSuffix=.naot")
+	BINLOG_SUFFIX="-naot"
+else
+	# Build the sample without NativeAOT
+	publish_extra+=("/p:AndroidUseAssemblyStore=false" "/p:RunAOTCompilation=false" "/p:PublishTrimmed=false" "/p:AndroidUseSharedRuntime=false")
+fi
+
+dotnet publish -f net10.0-android -p:TargetFrameworkOverride=net10.0-android -p:UseNativeRendering=true "${publish_extra[@]}" \
+	/p:AndroidPackageFormat=apk /p:RuntimeIdentifier=android-x64 /p:IsUiAutomationMappingEnabled=true \
+	-bl:"$BUILD_ARTIFACTSTAGINGDIRECTORY/android-app${BINLOG_SUFFIX}.binlog"

--- a/build/scripts/ios-uitest-run.sh
+++ b/build/scripts/ios-uitest-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euox pipefail
 IFS=$'\n\t'
 
 # Ensure this script has no BOM even if it ever gets committed with one again

--- a/build/stage-build-android-mobile.yml
+++ b/build/stage-build-android-mobile.yml
@@ -43,6 +43,34 @@ steps:
     OverWrite: false
     flattenFolders: false
 
+# NativeAOT builds run `git clean -xdf` so that previous build outputs don't interfere with the build.
+# Avoids "bizarre" build errors such as ``Internal.TypeSystem.TypeSystemException+TypeLoadException: Failed to load type 'System.Convert' from assembly 'System.Runtime,…'``
+- script: |
+    cd $(build.sourcesdirectory)/Uno.Gallery
+    git clean -xdf .
+    dotnet publish -m:1 -f:net10.0-android -p:TargetFrameworkOverride=net10.0-android -c:Release -r android-x64 -p:SkiaPublishAot=true "-p:ApplicationTitleVendorSuffix= (NAOT)" -p:ApplicationIdVendorSuffix=.naot -p:UseNativeRendering=$(UseNativeRendering) "/p:InformationalVersion=$(NBGV_InformationalVersion)" /p:AndroidSigningKeyStore=$(keyStore.secureFilePath) /p:AndroidSigningStorePass=$(AndroidSigningStorePass) /p:AndroidSigningKeyPass=$(AndroidSigningKeyPass) /p:AndroidSigningKeyAlias=$(AndroidSigningKeyAlias) /p:AndroidKeyStore=true /bl:$(build.artifactstagingdirectory)/build-naot-$(BuildForPlayStore).binlog
+  displayName: 'Build Android+NativeAOT Package'
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'],'False'))
+
+- script: |
+    cd $(build.sourcesdirectory)/Uno.Gallery
+    git clean -xdf .
+    dotnet publish -m:1 -f:net10.0-android -p:TargetFrameworkOverride=net10.0-android -c:Release -r android-x64 -p:SkiaPublishAot=true "-p:ApplicationTitleVendorSuffix= (NAOT)" -p:ApplicationIdVendorSuffix=.naot -p:UseNativeRendering=$(UseNativeRendering) "/p:InformationalVersion=$(NBGV_InformationalVersion)" /p:AndroidKeyStore=False /bl:$(build.artifactstagingdirectory)/build-naot-$(BuildForPlayStore).binlog
+  displayName: 'Build Android+NativeAOT Package (Fork)'
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'],'True'))
+
+- task: CopyFiles@2
+  displayName: 'Publish Android+NativeAOT netcore Binaries'
+  retryCountOnTaskFailure: 3
+  inputs:
+    SourceFolder: $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android
+    Contents: |
+      **/*.aab
+      **/*.apk
+    TargetFolder: $(build.artifactstagingdirectory)
+    CleanTargetFolder: false
+    OverWrite: false
+    flattenFolders: false
 
 - task: PublishBuildArtifacts@1
   retryCountOnTaskFailure: 3

--- a/build/stage-uitests-android.yml
+++ b/build/stage-uitests-android.yml
@@ -1,6 +1,6 @@
 ﻿jobs:
 - job: Android_Tests_Build
-  displayName: 'Android UI Tests'
+  displayName: 'Build Android UI Tests'
   timeoutInMinutes: 90
   variables:
     CI_Build: true
@@ -53,9 +53,58 @@
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: Android_UITest
 
+- job: Android_Tests_Build_NativeAOT
+  displayName: 'Build Android+NativeAOT UI Tests'
+  timeoutInMinutes: 90
+  variables:
+    CI_Build: true
+    SourceLinkEnabled: false
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 0
+    persistCredentials: true
+
+  - template: templates/dotnet-install-linux.yml
+    parameters:
+      UnoCheckParameters: '--tfm net10.0-android'
+
+  - template: templates/canary-updater.yml
+
+  - template: templates/host-cleanup-linux.yml
+
+  - bash: |
+      chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
+      NAOT=1 $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
+    displayName: 'Build Android+NativeAOT Tests'
+    env:
+      BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
+
+  - bash: |
+      echo "Publish output:"
+      ls -la $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64/publish || true
+      APK="$(ls $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64/publish/*.apk | head -n 1 || true)"
+      if [ ! -f "$APK" ]; then
+        echo "ERROR: No APK produced (verify AndroidPackageFormat=apk)"; exit 1; fi
+    displayName: Sanity check UITest APK contents
+
+  - task: CopyFiles@2
+    displayName: Copy Build Output
+    inputs:
+      SourceFolder: $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64
+      Contents: '**/*.apk'
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: Android_UITest_NativeAOT
 
 - job: Android_Tests
-  displayName: 'Android UI Tests'
+  displayName: 'Run Android UI Tests'
   dependsOn: Android_Tests_Build
   timeoutInMinutes: 90
   variables:
@@ -115,4 +164,67 @@
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
       ArtifactName: uno-uitest-tests
+      ArtifactType: Container
+
+- job: Android_Tests_NativeAOT
+  displayName: 'Run Android+NativeAOT UI Tests'
+  dependsOn: Android_Tests_Build_NativeAOT
+  timeoutInMinutes: 90
+  variables:
+    CI_Build: true
+    SourceLinkEnabled: false
+
+  pool:
+    vmImage: 'macos-14'
+
+  steps:
+  - checkout: self
+    clean: true
+    persistCredentials: true
+
+  - download: current
+    artifact: Android_UITest_NativeAOT
+
+  - task: UseDotNet@2
+    displayName: 'Ensure .NET SDK 10.0.102 for canary'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.102'
+      includePreviewVersions: true
+
+  - template: templates/canary-updater.yml
+
+  - task: PowerShell@2
+    displayName: 'Install coreutils'
+    inputs:
+      targetType: inline
+      script: |
+        brew install coreutils
+
+  - bash: |
+      export UNO_UITEST_ANDROIDAPK_BASEPATH=$(Pipeline.Workspace)/Android_UITest_NativeAOT
+      chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-run.sh
+      $(build.sourcesdirectory)/build/scripts/android-uitest-run.sh
+    displayName: 'Run Android+NativeAOT Tests'
+    env:
+      BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
+
+  - task: PublishTestResults@2
+    condition: always()
+    retryCountOnTaskFailure: 3
+    inputs:
+      testRunTitle: 'Android+NativeAOT Test Run'
+      testResultsFormat: 'NUnit'
+      testResultsFiles: '$(build.sourcesdirectory)/build/TestResult.xml'
+      failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: true
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+      ArtifactName: uno-uitest-tests-naot
       ArtifactType: Container

--- a/build/stage-uitests-ios.yml
+++ b/build/stage-uitests-ios.yml
@@ -48,7 +48,7 @@
 - job: iOS_Tests
   dependsOn: iOS_Tests_Build
   displayName: 'Run iOS UI Tests'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   variables:
     CI_Build: true
     SourceLinkEnabled: false
@@ -77,6 +77,7 @@
       chmod +x $(build.sourcesdirectory)/build/scripts/ios-uitest-run.sh
       $(build.sourcesdirectory)/build/scripts/ios-uitest-run.sh
     displayName: Run iOS Test
+    retryCountOnTaskFailure: 3
     env:
       BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
       BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"

--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -63,10 +63,12 @@ steps:
 
   - powershell: |
       cat global.json
+    displayName: 'Print current global.json'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
 
   - powershell: |
       dotnet tool uninstall uno.nuget.updater.tool --tool-path $(Agent.TempDirectory)
+    displayName: 'Uninstall uno.nuget.updater.tool'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
 
   - pwsh: |


### PR DESCRIPTION
chore: Introductory support for Native AOT builds

Context: https://github.com/unoplatform/uno/commit/559b1f7866028a1d23f74ba43c3e8614a8e9f284
Context: https://github.com/unoplatform/uno.toolkit.ui/commit/3ef6d6ce191db5bef1e18b670ac8d16b6367e9bc
Context: https://github.com/unoplatform/ShowMeTheXAML/pull/30

What do we want? To build and run with Native AOT!
Which in turn requires Uno.Sdk 6.6.0 or later for e.g. macOS:

	sed -i '' 's/"Uno.Sdk": ".*"/"Uno.Sdk": "6.6.0-dev.15"/g' global.json

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:PublishAot=true

…which promptly fails to build:

	…Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(120,5): error NETSDK1207:
	  Ahead-of-time compilation is not supported for the target framework.

~~ Build Support for Native AOT ~~

This specifically happens because `Uno.Gallery.csproj` has a
`@(ProjectReference)` to `Uno.Gallery.SourceGenerators.csproj`, which
is a .NET Standard 2.0 project, which doesn't support Native AOT.

To fix this, we need an "indirection": a property which we can set on
the command-line which causes `$(PublishAot)` to be set.

The "conventional" indirection used in unoplatform/uno SamplesApp and
in unoplatform/uno.chefs is `$(SkiaPublishAot)`.  This allows:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:SkiaPublishAot=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen

which *builds* successfully.  (It doesn't *run* successfully yet;
that's for later.)

~~ Build Support for Mobile Side-by-Side Installation ~~

Additionally, to "reasonably easily" support side-by-side execution
of Uno Gallery builds on e.g. iOS or Android, introduce support for
the following MSBuild properties (also done in unoplatform/uno.chefs):

  * `$(ApplicationIdVendorSuffix)`: Value to append to
    `$(ApplicationId)`, so that separate builds have separate names.

  * `$(ApplicationTitleVendorSuffix)`: Value to append to
    `$(ApplicationTitle)`, so that the different builds are
    distinguishable on app launchers.

On iOS, this allows side-by-side installs, but the iOS build didn't
use the `$(ApplicationTitle)` value.  This is because
`Uno.Gallery/Platforms/iOS/Info.plist` already had a
`CFBundleDisplayName` entry, which overrides `$(ApplicationTitle)`.
Remove the `CFBundleDisplayName` entry so that `$(ApplicationTitle)`
can be used to control `CFBundleDisplayName`.

~~ Build Support for Android + Native AOT ~~

Android + Native AOT builds would look like:

	dotnet publish -m:1 -r android-x64 -f net10.0-android -p:TargetFrameworkOverride=net10.0-android \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SkiaPublishAot=true \
	  "-p:ApplicationTitleVendorSuffix= (NAOT)" -p:ApplicationIdVendorSuffix=.naot

Note use of `-m:1` which is currently needed to avoid "bizarre"
errors such as:

	error MSB3030: Could not copy the file "bin/Release/net10.0-android/android-x64/native/Uno.Gallery.so" because it was not found.
	The target "IlcCompile" listed in an AfterTargets attribute at "/usr/local/share/dotnet/packs/Microsoft.Android.Sdk.Darwin/36.1.12/targets/Microsoft.Android.Sdk.NativeAOT.targets (206,7)" does not exist in the project, and will be ignored.

Remove `$(RunAOTCompilation)` from the Android build, as it's
presence prevents use of Native AOT / `-p:SkiaPublishAot=true`:

	/usr/local/share/dotnet/packs/Microsoft.Android.Sdk.Darwin/36.1.12/targets/Microsoft.Android.Sdk.Aot.targets(123,5): error
	  Precompiling failed for …/Uno.Gallery/obj/Release/net10.0-android/android-x64/aot-in/System.Collections.dll with exit code 134.
	  Runtime critical type System.RuntimeMethodHandle not found
	# and 24 more similar errors

~~ Desktop Startup Timing ~~

Introduce a trivial "hack" to support app starting time comparisons:
add a `--exit` command-line argument which causes the app to `Exit()`
at the end of `App.OnLaunched()`.  This allows using **time**(1) to
capture "app startup time":

	# CoreCLR:
	% dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SelfContained=true
	% time Uno.Gallery/bin/Release/net10.0-desktop/osx-x64/publish/Uno.Gallery --exit
	Uno.Gallery/bin/Release/net10.0-desktop/osx-x64/publish/Uno.Gallery --exit  1.08s user 0.32s system 70% cpu 1.982 total

	# Native AOT:
	% dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SelfContained=true -p:SkiaPublishAot=true
	% time Uno.Gallery/bin/Release/net10.0-desktop/osx-x64/publish/Uno.Gallery --exit
	Uno.Gallery/bin/Release/net10.0-desktop/osx-x64/publish/Uno.Gallery --exit  0.27s user 0.15s system 51% cpu 0.811 total

Or on Windows:

	Measure-Command { .\Uno.Gallery\bin\Release\net10.0-desktop\win-x64\publish\Uno.Gallery.exe --exit | Out-Default } | Select TotalMilliseconds

~~ iOS Startup Timing ~~

No changes are needed; to capture startup time on iOS:

 1. Install the `.ipa` onto your iOS device.

 2. Open **Instruments** (launch Xcode, then
    click Xcode > Open Developer Tool > Instruments)

 3. In Instruments, click File > New ⌘N.

 4. In the **Choose a Template…** window, select **App Launch**.

 5. In the Window which appears, in the central area is a **Target**
    section; from the **Device** dropdown, select your connected iOS
	device, and from the **Target** dropdowns, select **Launch** and
	the Uno Gallery app from the dropdown.

    Note: the Target dropdown shows `CFBundleExecutable` -- which is
	identical regardless of `$(ApplicationIdVendorSuffix)` or
	`$(ApplicationTitleVendorSuffix)` -- so this is	easiest to do if
	there is only *one* Uno.Gallery app installed.

 6. Click File > Record Trace ⌘R to start recording, which will launch
	the app on the device.

 7. When the app has finished launching, force-quit the app.
    Instruments will now start processing the data.

 8. Type ⌘4 to switch to **App Lifecycle**.  This shows a table of
    events with Start, Duration, and Narrative columns.
    Look for the *Launching - Initial Frame Rendering* Narrative entry.
    The Start value is the time taken to launch the app.

    |         Start |  Duration | Narrative                                         |
    | ------------: | --------: | :------------------------------------------------ |
    | 00:00.000.000 | 480.77 ms | The system took 480.77 ms to create the process.  |
    |             … |         … | …                                                 |
    | 00:01.306.446 |   4.41 ms | Launching – Initial Frame Rendering               |

    In this run, app startup time was 1.306 seconds.

~~ CI Updates ~~

Update `build/stage-build-android-mobile.yml` to also build Android
with Native AOT enabled.  Additionally, use [**folded** scalars][0]
for the build commands so that they can easily span multiple lines
without needing to worry about the line continuation character.
This increases readability and makes it obvious which parts of the
command lines are identical across build configurations.

Update `build/scripts/android-uitest-build.sh` to support generating
an Android+Native AOT `.aab` file when `NAOT=1`:

	NAOT=1 build/scripts/android-uitest-build.sh

Update `build/stage-uitests-android.yml` to *duplicate* the existing
jobs, with a new `Android_Tests_Build_NativeAOT` job which runs
`NAOT=1 android-uitest-build.sh` and uploads the artifacts to
`Android_UITest_NativeAOT`, and a new `Android_Tests_NativeAOT` job
which downloads the `Android_UITest_NativeAOT` artifacts and runs the
tests.

~~ Native AOT Runtime Fixes ~~

Begin fixing some of the runtime issues with Native AOT builds.
The following messages would appear on the Console during startup:

	fail: Uno.Gallery.Sample[0]
	      Failed to initialize data for `AutoSuggestBoxSamplePage`. dataType: Uno.Gallery.Views.Samples.AutoSuggestBoxSamplePageViewModel. Exception: System.MissingMethodException: No parameterless constructor defined for type 'Uno.Gallery.Views.Samples.AutoSuggestBoxSamplePageViewModel'.
	         at System.ActivatorImplementation.CreateInstance(Type, Boolean) + 0x180
	         at Uno.Gallery.Sample.CreateData(Type) + 0x3a
	fail: Uno.Gallery.Sample[0]
	      Failed to initialize data for `BarometerSamplePage`. dataType: BarometerSamplePageViewModel. Exception: System.MissingMethodException: No parameterless constructor defined for type 'BarometerSamplePageViewModel'.
	         at System.ActivatorImplementation.CreateInstance(Type, Boolean) + 0x180
	         at Uno.Gallery.Sample.CreateData(Type) + 0x3a

Plus 19 more similar messages.

These `fail` messages appear because of missing "reflection metadata"
(unoplatform/uno@559b1f78), and we can fix these by using the
`[DynamicallyAccessedMembers]` and `[DynamicDependency]` attributes.

In order to use `[DynamicallyAccessedMembers]`, we need either a
generic type parameter or a `typeof()` expression.  Searching around,
there are useful places `typeof()` is already used; from
`Uno.Gallery.SourceGenerators` generated output, in
`$(CompilerGeneratedFilesOutputPath)`, we have:

	// …/App.Samples.g.cs
	public partial class App {
	  public static Sample[] GetSamples()
	  {
	    return new[] {
	      // …
	      new global::Uno.Gallery.Sample(new global::Uno.Gallery.SamplePageAttribute(category: (global::Uno.Gallery.SampleCategory)(2), title: "AutoSuggestBox", source: (global::Uno.Gallery.SourceSdk)(0), glyph: "") { Description = @"Represents a text control that makes suggestions to users as they enter text.", DocumentationLink = "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox?view=windows-app-sdk-1.3", DataType = typeof(global::Uno.Gallery.Views.Samples.AutoSuggestBoxSamplePageViewModel), SortOrder = 2147483647 }, typeof(Uno.Gallery.Views.Samples.AutoSuggestBoxSamplePage)),
	      // …
	    };
	  }
	}

Which has the handy benefit of containing *both*
`AutoSuggestBoxSamplePage` and `AutoSuggestBoxSamplePageViewModel`,
which were mentioned in the `fail` message.

This in turn makes the fix straightforward: update the `Sample` and
`SamplePageAttribute` types to use `[DynamicallyAccessedMembers]` on
their respective `Type` parameters and properties to preserve
constructors (from the original message) and properties, which almost
certainly will be needed anyway.
(Property preservation is reflexive at this point.)

If you select **UI components > AutoSuggestBox** in the left-side
tree view, then click the `<>` "Show XAML" button, nothing is shown
*and* the following messages are written to the Console:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ShowMeTheXAML:XamlDisplayExtensions.Header] property getter does not exist on type [ShowMeTheXAML.XamlDisplay]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ShowMeTheXAML:XamlDisplayExtensions.Description] property getter does not exist on type [ShowMeTheXAML.XamlDisplay]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ShowMeTheXAML:XamlDisplayExtensions.Options] property getter does not exist on type [ShowMeTheXAML.XamlDisplay]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ShowMeTheXAML:XamlDisplayExtensions.PrettyXaml] property getter does not exist on type [ShowMeTheXAML.XamlDisplay]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ShowMeTheXAML:XamlDisplayExtensions.ShowXaml] property getter does not exist on type [ShowMeTheXAML.XamlDisplay]

This is because WPF Attached Properties require use of
`[DynamicDependency]` to ensure that the required methods are
accessible via Reflection; see also unoplatform/uno.toolkit.ui@3ef6d6ce.
Update all use of `DependencyProperty.RegisterAttached()` so that
required methods are retained.

Unfortunately, while this fixes the above `fail` messages, clicking
the `<>` "Show XAML" button still does nothing.

Fixing the `<>` "Show XAML" button requires
unoplatform/ShowMeTheXAML#30 and replacing the existing
`XamlDisplay.Init()` invocation with `XamlDictionary.Init()`.
Bump to Uno.ShowMeTheXAML 2.0.0-dev0026 to get this fix.
Unfortunately, this breaks the build:

	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Windows.SDK.BuildTools from 10.0.28000.1-RTM to 10.0.26100.7463. Reference the package directly from the project to select a different version.
	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605:  Uno.Gallery -> Uno.ShowMeTheXAML 2.0.0-dev0026 -> Microsoft.Windows.SDK.BuildTools (>= 10.0.28000.1-RTM)
	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605:  Uno.Gallery -> Microsoft.Windows.SDK.BuildTools (>= 10.0.26100.7463)
	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.WindowsAppSDK from 1.8.260101001 to 1.7.250909003. Reference the package directly from the project to select a different version.
	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605:  Uno.Gallery -> Uno.ShowMeTheXAML 2.0.0-dev0026 -> Microsoft.WindowsAppSDK (>= 1.8.260101001)
	D:\a\1\s\Uno.Gallery\Uno.Gallery.csproj : error NU1605:  Uno.Gallery -> Microsoft.WindowsAppSDK (>= 1.7.250909003)

Fix this error by explicitly adding `Microsoft.WindowsAppSDK` and
`Microsoft.Windows.SDK.BuildTools` NuGet package references which
match the versions used by `Uno.ShowMeTheXAML`.

Additionally, `XamlDictionary.Init()` *cannot* be used when building
for `WINDOWS`/WinRT, for not entirely understood reasons.  The short
is that the `BuildXamlDictionary` target from
`Uno.ShowMeTheXAML.MSBuild.targets` *is not executed* when building for
`WINDOWS`/WinRT, which means that the generated `XamlDictionary.g.cs`
does not exist.  But ***why*** isn't it executed?!  I doesn't know.

If you select **UI components > BreadcrumbBar** in the left-side
tree view, then the **BreadcrumbBar with Custom DataTemplate**
section on the right-hand page doesn't show anything, and Console
output contains:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Name] property getter does not exist on type [Uno.Gallery.Entities.Data.Folder]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [ItemCount] property getter does not exist on type [Uno.Gallery.Entities.Data.Folder]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Description] property getter does not exist on type [Uno.Gallery.Entities.Data.Folder]

Fix this by adding `[Microsoft.UI.Xaml.Data.Bindable]` to
`Uno.Gallery.Entities.Data.Folder`.  The use of `[Bindable]` causes
the `Uno.UI.SourceGenerators.BindableTypeProvider` source generator
to emit `BindableType(…, typeof(Folder))` to `BindableMetadata.g.cs`,
which cause all public properties to be added to reflection metadata.

Add `[Bindable]` to all other types containing properties within
`Uno.Gallery.Entities.Data`.  This fixes a number of other samples
and messages such as:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Color] property getter does not exist on type [Uno.Gallery.Entities.Data.Record]

If you select **UI features > Binding** in the left-side
tree view, the right-hand panel would be subtly different between
CoreCLR and Native AOT:

  * CoreCLR: `The length is: [empty]`
  * Native AOT: `The length is:`

Worse, if you enter text into "myTextBox", the bound fields properly
update under CoreCLR.  For example, enter "123" into "myTextBox",
and CoreCLR would show:

> The text of myTextBox is: 123
> The length is: 3

Under Native AOT, *nothing* updates.

Console output contains:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Text] property getter does not exist on type [Uno.Gallery.Views.Samples.BindingSamplePageViewModel]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [TextLength] property getter does not exist on type [Uno.Gallery.Views.Samples.BindingSamplePageViewModel]

Fix this by adding `[Bindable]` to `BindingSamplePageViewModel`.
(Which means "just add `[Bindable]`!" is quickly becoming my favorite
answer to everything.  Unless the type has `required` or `init`-only
properties; see also unoplatform/uno.chefs@06f4f804.)

Continue this pattern: update all types which implement
`INotifyPropertyChanged` or inherit from a type which implements
`INotifyPropertyChanged` to have `[Bindable]`.  This fixes the
following `fail` messages, among others:

	The [AccelerationX] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [AccelerationY] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [AccelerationZ] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [AccelerometerAvailable] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [ButtonContent] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [ButtonContent] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [GeolocatedAccuracy] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [GeolocatedAltitude] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [GeolocatedLatitude] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [GeolocatedLongitude] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [GeolocatedTimestamp] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]
	The [LastReadTimestamp] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [LastShakeTimestamp] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [ListenButtonContent] property getter does not exist on type [Uno.Gallery.Views.Samples.ClipboardSamplePageViewModel]
	The [Message] property getter does not exist on type [Uno.Gallery.Views.Samples.ClipboardSamplePageViewModel]
	The [ReportInterval] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [ShakeCount] property getter does not exist on type [Uno.Gallery.Views.Samples.AccelerometerSamplePageViewModel]
	The [ToggleButtonContent] property getter does not exist on type [Uno.Gallery.Views.Samples.GeolocatorSamplePageViewModel]

[0]: https://yaml-multiline.info
