### PR TITLE
feat: Test Android+Skia+NativeAOT on CI

### DIFF
--- a/Uno.Gallery/Platforms/Android/MainInstrumentation.Android.cs
+++ b/Uno.Gallery/Platforms/Android/MainInstrumentation.Android.cs
@@ -1,0 +1,21 @@
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+
+namespace Uno.Gallery
+{
+	[Instrumentation(Name = "my.MainInstrumentation")]
+	public class MainInstrumentation : Android.App.Instrumentation
+	{
+		public MainInstrumentation(IntPtr handle, JniHandleOwnership ownership)
+		    : base(handle, ownership)
+		{
+		}
+
+		public override void OnCreate(Bundle? savedInstanceState)
+		{
+			base.OnCreate(savedInstanceState);
+			Finish(Result.Ok, null);
+		}
+	}
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,6 +251,12 @@ stages:
   jobs:
   - template: build/stage-uitests-android.yml
 
+- stage: Android_Skia_NativeAOT_Instrumentation_Tests
+  displayName: 'Android+Skia+NativeAOT Instrumentation Tests'
+  dependsOn: []
+  jobs:
+  - template: build/stage-tests-android.yml
+
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries/dev') }}:
   - template: build/templates/canary-publish/stage-publish-wasm-canary.yml
   - template: build/templates/canary-publish/stage-publish-ios-canary.yml

--- a/build/scripts/android-sdk-emu.inc.sh
+++ b/build/scripts/android-sdk-emu.inc.sh
@@ -1,0 +1,157 @@
+# Prepare and launch the Android Emulator
+#
+# Usage:
+#
+#   source build/scripts/android-sdk-emu.inc.sh
+#
+# Input Environment Variables:
+#
+#   BUILD_ARTIFACTSTAGINGDIRECTORY: Required
+#   BUILD_SOURCESDIRECTORY: Required
+#   ANDROID_SIMULATOR_APILEVEL: Optional; The Android API level to target for the emulator. Default is API-28.
+#   ANDROID_SIMULATOR_ABI: Optional; The Android ABI to target for the emulator. Default is x86_64.
+#   CMDLINETOOLS: Optional; Android SDK cmdlinetools package name to install.
+#     Default is commandlinetools-mac-8512546_latest.zip on macOS and commandlinetools-linux-8512546_latest.zip on Linux.
+#
+# Output Environment Variables:
+#
+#   ANDROID_HOME, ANDROID_SDK_ROOT: Where an Android SDK is provisioned; subdir of $BUILD_SOURCESDIRECTORY
+#   ANDROID_SERIAL: If an emulator is started, the serial identifier to use for adb commands targeting that emulator
+#     Note: used *automatically* by `adb`; see `adb --help` for details.
+#   CMDLINETOOLS: Android SDK cmdlinetools package name that was installed.
+#   LATEST_CMDLINE_TOOLS_PATH: Path to Android SDK cmdlinetools installation
+#   UNO_UITEST_PLATFORM: The platform being tested (Android)
+#   UNO_UITEST_SCREENSHOT_PATH: Where screenshots/etc. should be copied to; subdir of $BUILD_ARTIFACTSTAGINGDIRECTORY
+
+# Override Android SDK tooling
+
+# also used for log files
+export ANDROID_HOME="$BUILD_SOURCESDIRECTORY/build/android-sdk"
+export ANDROID_SDK_ROOT="$BUILD_SOURCESDIRECTORY/build/android-sdk"
+export LATEST_CMDLINE_TOOLS_PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest"
+export UNO_EMULATOR_INSTALLED="$BUILD_SOURCESDIRECTORY/build/.emulator_started"
+export UNO_UITEST_PLATFORM=Android
+export UNO_UITEST_SCREENSHOT_PATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/android"
+
+if [ -z "${CMDLINETOOLS:-}" ]; then
+	case `uname` in
+		Darwin)
+			export CMDLINETOOLS="commandlinetools-mac-8512546_latest.zip"
+			;;
+		Linux)
+			export CMDLINETOOLS="commandlinetools-linux-8512546_latest.zip"
+			;;
+		*)
+			echo "Unsupported OS: `uname`. Please set the CMDLINETOOLS environment variable to the appropriate cmdline-tools Android SDK package basename for your OS."
+			exit 1
+			;;
+	esac
+fi
+
+mkdir -p "$ANDROID_HOME"
+
+if [ -d "$LATEST_CMDLINE_TOOLS_PATH" ]; then
+	rm -rf "$LATEST_CMDLINE_TOOLS_PATH"
+fi
+
+wget "https://dl.google.com/android/repository/$CMDLINETOOLS"
+unzip "$CMDLINETOOLS" -d "$ANDROID_HOME/cmdline-tools"
+rm "$CMDLINETOOLS"
+mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$LATEST_CMDLINE_TOOLS_PATH"
+
+if [[ -f "$ANDROID_HOME/platform-tools/platform-tools/adb" ]]; then
+	# It appears that the platform-tools 29.0.6 are extracting into an incorrect path
+	mv "$ANDROID_HOME/platform-tools/platform-tools"/* "$ANDROID_HOME/platform-tools"
+fi
+
+export ANDROID_SIMULATOR_APILEVEL="${ANDROID_SIMULATOR_APILEVEL:-28}"
+export ANDROID_SIMULATOR_ABI="${ANDROID_SIMULATOR_ABI:-x86_64}"
+
+AVD_NAME=xamarin_android_emulator
+AVD_CONFIG_FILE="$HOME/.android/avd/$AVD_NAME.avd/config.ini"
+SDK_MGR_TOOLS_FLAG=.sdk_toolkit_installed
+EMU_UPDATE_FILE="$HOME/.android/emu-update-last-check.ini"
+
+mkdir -p "$UNO_UITEST_SCREENSHOT_PATH"
+
+install_android_sdk() {
+	SIMULATOR_APILEVEL="$1"
+
+	if [[ ! -f "$SDK_MGR_TOOLS_FLAG" ]]; then
+		touch "$SDK_MGR_TOOLS_FLAG"
+
+		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'tools'| tr '\r' '\n' | uniq
+		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'platform-tools'  | tr '\r' '\n' | uniq
+		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'build-tools;36.0.0' | tr '\r' '\n' | uniq
+		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'extras;android;m2repository' | tr '\r' '\n' | uniq
+	fi
+
+	echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install "platforms;android-$SIMULATOR_APILEVEL" | tr '\r' '\n' | uniq
+	echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install "system-images;android-$SIMULATOR_APILEVEL;google_apis_playstore;$ANDROID_SIMULATOR_ABI" | tr '\r' '\n' | uniq
+}
+
+if [[ ! -f "$EMU_UPDATE_FILE" ]]; then
+	touch "$EMU_UPDATE_FILE"
+fi
+
+if [[ -f "$AVD_CONFIG_FILE" ]]; then
+
+	echo "warning: not creating new AVD, as config file already exists at $AVD_CONFIG_FILE."
+	echo "warning: If the emulator fails to start or work correctly, try deleting the AVD and letting this script create it again."
+
+else
+	# Install AVD files
+	install_android_sdk "$ANDROID_SIMULATOR_APILEVEL"
+	install_android_sdk 36
+
+	if [[ -f "$ANDROID_HOME/platform-tools/platform-tools/adb" ]]; then
+		# It appears that the platform-tools 29.0.6 are extracting into an incorrect path
+		mv "$ANDROID_HOME/platform-tools/platform-tools"/* "$ANDROID_HOME/platform-tools"
+	fi
+
+	AVD_IMAGE_NAME="system-images;android-$ANDROID_SIMULATOR_APILEVEL;google_apis_playstore;$ANDROID_SIMULATOR_ABI"
+
+	# Create emulator
+	echo "no" | "$LATEST_CMDLINE_TOOLS_PATH/bin/avdmanager" create avd -n "$AVD_NAME" \
+	  --abi "$ANDROID_SIMULATOR_ABI" -k "$AVD_IMAGE_NAME" --sdcard 128M --force
+
+	# based on https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#hardware
+	# >> Agents that run macOS images are provisioned on Mac pros with a 3 core CPU, 14 GB of RAM, and 14 GB of SSD disk space.
+	echo "hw.cpu.ncore=3" >> "$AVD_CONFIG_FILE"
+
+	# Bump the heap size as the tests are stressing the application
+	echo "vm.heapSize=256M" >> "$AVD_CONFIG_FILE"
+
+	"$ANDROID_HOME/emulator/emulator" -list-avds
+
+	echo "Checking for hardware acceleration"
+	"$ANDROID_HOME/emulator/emulator" -accel-check
+fi
+
+# kickstart ADB
+if "$ANDROID_HOME/platform-tools/adb" devices | grep -v 'List of devices attached' | grep device >/dev/null 2>&1 ; then
+	# we have an existing device/emulator; restart it to avoid running first-time tasks
+	"$ANDROID_HOME/platform-tools/adb" reboot
+
+	# Wait for the emulator to finish booting
+	source "$BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh" 500
+else
+	echo "Starting emulator"
+
+	# Start emulator in background
+	nohup "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" -skin 1280x800 -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim > "$UNO_UITEST_SCREENSHOT_PATH/android-emulator-log.txt" 2>&1 &
+
+	# Wait for the emulator to finish booting
+	source "$BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh" 500
+
+	export ANDROID_SERIAL=$("$ANDROID_HOME/platform-tools/adb" devices | grep -v 'List of devices attached' | grep emulator- | awk '{print $1}' | tail -n 1)
+fi
+
+# Wait for the emulator to finish booting
+source "$BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh" 500
+
+"$ANDROID_HOME/platform-tools/adb" devices
+echo "Emulator started"
+
+echo "Device System Properties:"
+"$ANDROID_HOME/platform-tools/adb" shell getprop

--- a/build/scripts/android-test-run.sh
+++ b/build/scripts/android-test-run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+IFS=$'\n\t'
+
+# `adb install` requires signed APK files, so only look for them
+APK_FROM_ARTIFACT="$(ls "$UNO_TEST_ANDROIDAPK_BASEPATH"/*-Signed.apk 2>/dev/null | head -n 1 || true)"
+APK_FROM_LOCAL="$(ls "$BUILD_SOURCESDIRECTORY/Uno.Gallery/bin/Release/net10.0-android/android-x64/publish"/*-Signed.apk 2>/dev/null | head -n 1 || true)"
+
+if [ -f "$APK_FROM_ARTIFACT" ]; then
+	export UNO_TEST_ANDROIDAPK_PATH="$APK_FROM_ARTIFACT"
+elif [ -f "$APK_FROM_LOCAL" ]; then
+	export UNO_TEST_ANDROIDAPK_PATH="$APK_FROM_LOCAL"
+else
+	echo "ERROR: APK not found (neither artifact nor local publish)."
+	exit 1
+fi
+
+echo "Using APK: $UNO_TEST_ANDROIDAPK_PATH"
+
+# Need API-34 not API-28 to work around: https://github.com/unoplatform/uno/pull/22571
+export ANDROID_SIMULATOR_APILEVEL=34
+
+source "$BUILD_SOURCESDIRECTORY/build/scripts/android-sdk-emu.inc.sh"
+
+"$ANDROID_HOME/platform-tools/adb" install -r "$UNO_TEST_ANDROIDAPK_PATH"
+
+package_name=$("$LATEST_CMDLINE_TOOLS_PATH/bin/apkanalyzer" manifest application-id "$UNO_TEST_ANDROIDAPK_PATH")
+
+INSTRUMENTATION_OUTPUT=$("$ANDROID_HOME/platform-tools/adb" shell am instrument -w $package_name/my.MainInstrumentation || true)
+echo "Instrumentation output:"
+echo "$INSTRUMENTATION_OUTPUT"
+
+## Dump the emulator's system log
+"$ANDROID_HOME/platform-tools/adb" shell logcat -d > "$BUILD_ARTIFACTSTAGINGDIRECTORY/android-device-log.txt"
+
+# if we created the emulator instance, kill it
+if [ -n "${ANDROID_SERIAL:-}" ]; then
+	echo "Shutting down emulator $ANDROID_SERIAL"
+	"$ANDROID_HOME/platform-tools/adb" emu kill
+fi
+
+if echo "$INSTRUMENTATION_OUTPUT" | grep -q "INSTRUMENTATION_CODE: -1"; then
+	echo "SUCCESS: Instrumentation completed successfully (INSTRUMENTATION_CODE: -1)"
+else
+	echo "ERROR: Expected 'INSTRUMENTATION_CODE: -1' not found in instrumentation output."
+	exit 1
+fi

--- a/build/scripts/android-uitest-build.sh
+++ b/build/scripts/android-uitest-build.sh
@@ -55,6 +55,12 @@ else
 	publish_extra+=("/p:AndroidUseAssemblyStore=false" "/p:RunAOTCompilation=false" "/p:PublishTrimmed=false" "/p:AndroidUseSharedRuntime=false")
 fi
 
-dotnet publish -f net10.0-android -p:TargetFrameworkOverride=net10.0-android -p:UseNativeRendering=true "${publish_extra[@]}" \
-	/p:AndroidPackageFormat=apk /p:RuntimeIdentifier=android-x64 /p:IsUiAutomationMappingEnabled=true \
+if [ "${SKIA:-0}" = "1" ]; then
+	publish_extra+=("-p:UseSkiaRendering=true")
+else
+	publish_extra+=("-p:UseNativeRendering=true" "/p:IsUiAutomationMappingEnabled=true")
+fi
+
+dotnet publish -f net10.0-android -p:TargetFrameworkOverride=net10.0-android "${publish_extra[@]}" \
+	/p:AndroidPackageFormat=apk /p:RuntimeIdentifier=android-x64 \
 	-bl:"$BUILD_ARTIFACTSTAGINGDIRECTORY/android-app${BINLOG_SUFFIX}.binlog"

--- a/build/scripts/android-uitest-run.sh
+++ b/build/scripts/android-uitest-run.sh
@@ -5,12 +5,9 @@ IFS=$'\n\t'
 # echo commands
 set -x
 
-export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/android
-export UNO_UITEST_PLATFORM=Android
 export UNO_UITEST_PROJECT=$BUILD_SOURCESDIRECTORY/Uno.Gallery.UITests
 export UNO_UITEST_ANDROID_PROJECT=$BUILD_SOURCESDIRECTORY/Uno.Gallery
 export UNO_UITEST_BINARY=$BUILD_SOURCESDIRECTORY/Uno.Gallery.UITests/bin/Release/net47/Uno.Gallery.UITests.dll
-export UNO_EMULATOR_INSTALLED=$BUILD_SOURCESDIRECTORY/build/.emulator_started
 export UITEST_TEST_TIMEOUT=60m
 
 # Prefer the signed APK from build artifacts (Windows job) when available,
@@ -38,120 +35,9 @@ touch "$tmpdir/assemblies.blob"
 ( cd "$tmpdir" && zip -q "$UNO_UITEST_ANDROIDAPK_PATH" assemblies.blob )
 rm -rf "$tmpdir"
 
-export ANDROID_SIMULATOR_APILEVEL=28
-
-AVD_NAME=xamarin_android_emulator
-AVD_CONFIG_FILE=~/.android/avd/$AVD_NAME.avd/config.ini
-
-# Override Android SDK tooling
-export ANDROID_HOME=$BUILD_SOURCESDIRECTORY/build/android-sdk
-export ANDROID_SDK_ROOT=$BUILD_SOURCESDIRECTORY/build/android-sdk
-export LATEST_CMDLINE_TOOLS_PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest
-export CMDLINETOOLS=commandlinetools-mac-8512546_latest.zip
-mkdir -p $ANDROID_HOME
-
-if [ -d $LATEST_CMDLINE_TOOLS_PATH ];
-then
-	rm -rf $LATEST_CMDLINE_TOOLS_PATH
-fi
-
-wget https://dl.google.com/android/repository/$CMDLINETOOLS
-unzip $CMDLINETOOLS -d $ANDROID_HOME/cmdline-tools
-rm $CMDLINETOOLS
-mv $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools $LATEST_CMDLINE_TOOLS_PATH
-
-if [[ -f $ANDROID_HOME/platform-tools/platform-tools/adb ]]
-then
-	# It appears that the platform-tools 29.0.6 are extracting into an incorrect path
-	mv $ANDROID_HOME/platform-tools/platform-tools/* $ANDROID_HOME/platform-tools
-fi
-
-AVD_NAME=xamarin_android_emulator
-AVD_CONFIG_FILE=~/.android/avd/$AVD_NAME.avd/config.ini
-EMU_UPDATE_FILE=~/.android/emu-update-last-check.ini
-SDK_MGR_TOOLS_FLAG=.sdk_toolkit_installed
-
-mkdir -p $UNO_UITEST_SCREENSHOT_PATH
-
-install_android_sdk() {
-	SIMULATOR_APILEVEL=$1
-
-	if [[ ! -f $SDK_MGR_TOOLS_FLAG ]];
-	then
-		touch $SDK_MGR_TOOLS_FLAG 
-
-		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'tools'| tr '\r' '\n' | uniq
-		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'platform-tools'  | tr '\r' '\n' | uniq
-		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'build-tools;36.0.0' | tr '\r' '\n' | uniq
-		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'extras;android;m2repository' | tr '\r' '\n' | uniq
-	fi
-	
-	echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install "platforms;android-$SIMULATOR_APILEVEL" | tr '\r' '\n' | uniq
-	echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install "system-images;android-$SIMULATOR_APILEVEL;google_apis_playstore;x86_64" | tr '\r' '\n' | uniq
-}
-
-
-if [[ ! -f $EMU_UPDATE_FILE ]];
-then
-	touch $EMU_UPDATE_FILE
-fi
-
-if [[ ! -f $AVD_CONFIG_FILE ]];
-then
-	# Install AVD files
-	install_android_sdk $ANDROID_SIMULATOR_APILEVEL
-	install_android_sdk 34
-	install_android_sdk 35
-	install_android_sdk 36
-
-	if [[ -f $ANDROID_HOME/platform-tools/platform-tools/adb ]]
-	then
-		# It appears that the platform-tools 29.0.6 are extracting into an incorrect path
-		mv $ANDROID_HOME/platform-tools/platform-tools/* $ANDROID_HOME/platform-tools
-	fi
-
-	# Create emulator
-	echo "no" | $LATEST_CMDLINE_TOOLS_PATH/bin/avdmanager create avd -n "$AVD_NAME" --abi "x86_64" -k "system-images;android-$ANDROID_SIMULATOR_APILEVEL;google_apis_playstore;x86_64" --sdcard 128M --force
-
-	# based on https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#hardware
-	# >> Agents that run macOS images are provisioned on Mac pros with a 3 core CPU, 14 GB of RAM, and 14 GB of SSD disk space.
-	echo "hw.cpu.ncore=3" >> $AVD_CONFIG_FILE
-
-	# Bump the heap size as the tests are stressing the application
-	echo "vm.heapSize=256M" >> $AVD_CONFIG_FILE
-
-	$ANDROID_HOME/emulator/emulator -list-avds
-
-	echo "Checking for hardware acceleration"
-	$ANDROID_HOME/emulator/emulator -accel-check
-
-	echo "Starting emulator"
-
-	# kickstart ADB
-	$ANDROID_HOME/platform-tools/adb devices
-
-	# Start emulator in background
-	nohup $ANDROID_HOME/emulator/emulator -avd "$AVD_NAME" -skin 1280x800 -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim > $UNO_UITEST_SCREENSHOT_PATH/android-emulator-log.txt 2>&1 &
-
-	# Wait for the emulator to finish booting
-	source $BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh 500
-
-else
-	# Restart the emulator to avoid running first-time tasks
-	$ANDROID_HOME/platform-tools/adb reboot
-
-	# Wait for the emulator to finish booting
-	source $BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh 500
-fi
+source "$BUILD_SOURCESDIRECTORY/build/scripts/android-sdk-emu.inc.sh"
 
 cp $UNO_UITEST_ANDROIDAPK_PATH $UNO_UITEST_SCREENSHOT_PATH
-
-# Wait for the emulator to finish booting
-source $BUILD_SOURCESDIRECTORY/build/scripts/android-uitest-wait-systemui.sh 500
-
-$ANDROID_HOME/platform-tools/adb devices
-
-echo "Emulator started"
 
 cd $UNO_UITEST_PROJECT
 
@@ -167,3 +53,9 @@ dotnet test \
 $ANDROID_HOME/platform-tools/adb shell logcat -d > $BUILD_ARTIFACTSTAGINGDIRECTORY/android-device-log.txt
 
 $ANDROID_HOME/platform-tools/adb exec-out screencap -p > $BUILD_ARTIFACTSTAGINGDIRECTORY/android-end-run.png
+
+# if we created the emulator instance, kill it
+if [ -n "${ANDROID_SERIAL:-}" ]; then
+	echo "Shutting down emulator $ANDROID_SERIAL"
+	"$ANDROID_HOME/platform-tools/adb" emu kill
+fi

--- a/build/stage-tests-android.yml
+++ b/build/stage-tests-android.yml
@@ -1,0 +1,105 @@
+jobs:
+- job: Android_Skia_NativeAOT_Instrumentation_Build
+  displayName: 'Build Android+Skia+NativeAOT Instrumentation APK'
+  timeoutInMinutes: 90
+  variables:
+    CI_Build: true
+    SourceLinkEnabled: false
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 0
+    persistCredentials: true
+
+  - template: templates/dotnet-install-linux.yml
+    parameters:
+      UnoCheckParameters: '--tfm net10.0-android'
+
+  - template: templates/canary-updater.yml
+
+  - template: templates/host-cleanup-linux.yml
+
+  - bash: |
+      chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
+      NAOT=1 SKIA=1 $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
+    displayName: 'Build Android+Skia+NativeAOT APK'
+    env:
+      BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
+
+  - bash: |
+      echo "Publish output:"
+      ls -la $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64/publish || true
+      APK="$(ls $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64/publish/*.apk | head -n 1 || true)"
+      if [ ! -f "$APK" ]; then
+        echo "ERROR: No APK produced (verify AndroidPackageFormat=apk)";
+        exit 1;
+      fi
+    displayName: Sanity check NativeAOT APK
+
+  - task: CopyFiles@2
+    displayName: Copy Build Output
+    inputs:
+      SourceFolder: $(build.sourcesdirectory)/Uno.Gallery/bin/Release/net10.0-android/android-x64
+      Contents: '**/*.apk'
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: Android_Skia_NativeAOT_Instrumentation
+
+- job: Android_Skia_NativeAOT_Instrumentation_Run
+  displayName: 'Run Android+Skia+NativeAOT Instrumentation Test'
+  dependsOn: Android_Skia_NativeAOT_Instrumentation_Build
+  timeoutInMinutes: 90
+  variables:
+    CI_Build: true
+    SourceLinkEnabled: false
+
+  pool:
+    vmImage: 'macos-14'
+
+  steps:
+  - checkout: self
+    clean: true
+    persistCredentials: true
+
+  - download: current
+    artifact: Android_Skia_NativeAOT_Instrumentation
+
+  - task: UseDotNet@2
+    displayName: 'Ensure .NET SDK 10.0.102 for canary'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries')
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.102'
+      includePreviewVersions: true
+
+  - template: templates/canary-updater.yml
+
+  - task: PowerShell@2
+    displayName: 'Install coreutils'
+    inputs:
+      targetType: inline
+      script: |
+        brew install coreutils
+
+  - bash: |
+      export UNO_TEST_ANDROIDAPK_BASEPATH="$(Pipeline.Workspace)/Android_Skia_NativeAOT_Instrumentation"
+      chmod +x "$(build.sourcesdirectory)/build/scripts/android-test-run.sh"
+      "$(build.sourcesdirectory)/build/scripts/android-test-run.sh"
+    displayName: 'Run Android+Skia+NativeAOT Instrumentation Test'
+    env:
+      BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+      ArtifactName: uno-naot-instrumentation-tests
+      ArtifactType: Container


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/Uno.Gallery/issues/1241

Context: https://github.com/unoplatform/uno/pull/22676
Context: https://github.com/unoplatform/uno/issues/22832
Context: https://github.com/unoplatform/uno/pull/22834

Commit unoplatform/uno#22676 *broke* Android+Skia+NativeAOT startup; see also unoplatform/uno#22832.  This is noticeable when building and launching Uno.Gallery for Android+Skia+NativeAOT:

	git clone https://github.com/unoplatform/Uno.Gallery.git
	cd Uno.Gallery
	git checkout b1943997ac1982722c240e3350ba3e0d92c5f55e
	# anything between 6.6.0-dev.92 and "the fix" will fail
	sed -i '' 's/"Uno.Sdk": ".*"/"Uno.Sdk": "6.6.0-dev.127"/g' global.json
	dotnet publish -m:1 -r android-x64 -f net10.0-android -p:TargetFrameworkOverride=net10.0-android \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SkiaPublishAot=true \
	  "-p:ApplicationTitleVendorSuffix= (NAOT)" -p:ApplicationIdVendorSuffix=.naot
	adb logcat > log.txt &
	adb install Uno.Gallery/bin/Release/net10.0-android/android-x64/publish/com.nventive.uno.ui.demo.naot-Signed.apk
	adb shell am start com.nventive.uno.ui.demo.naot/crc64a57a145253f0f267.MainActivity

After launching the app, it crashes with:

	E Java.InteropRuntime: JavaInteropRuntime.init: error: System.IO.FileNotFoundException: IO_FileNotFound_FileName, Uno.UI.BindingHelper.Android
	E JavaInteropRuntime: IO_FileName_Name, Uno.UI.BindingHelper.Android
	E JavaInteropRuntime:    at Internal.Runtime.TypeLoaderExceptionHelper.CreateFileNotFoundException(ExceptionStringID, String) + 0x4a
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeMapping.GetTypeByJniNameHashIndex(Int32) + 0x12
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeMapping.TryGetType(String, Type&) + 0x85
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeManager.<GetTypesForSimpleReference>d__6.MoveNext() + 0xd1
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniTypeManager.<CreateGetTypesEnumerator>d__28.MoveNext() + 0x103
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.<CreatePeerInstance>g__GetTypeAssignableTo|28_0(JniTypeSignature, Type) + 0x54
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.CreatePeerInstance(JniObjectReference&, Type, JniObjectReference&, JniObjectReferenceOptions) + 0x69
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.CreatePeer(JniObjectReference&, JniObjectReferenceOpti
	E DOTNET  : Unhandled exception.
	E DOTNET  : System.IO.FileNotFoundException: IO_FileNotFound_FileName, Uno.UI.BindingHelper.Android
	E DOTNET  : IO_FileName_Name, Uno.UI.BindingHelper.Android
	E DOTNET  :    at Internal.Runtime.TypeLoaderExceptionHelper.CreateFileNotFoundException(ExceptionStringID, String) + 0x4a
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeMapping.GetTypeByJniNameHashIndex(Int32) + 0x12
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeMapping.TryGetType(String, Type&) + 0x85
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeManager.<GetTypesForSimpleReference>d__6.MoveNext() + 0xd1
	E DOTNET  :    at Java.Interop.JniRuntime.JniTypeManager.<CreateGetTypesEnumerator>d__28.MoveNext() + 0x103
	E DOTNET  :    at System.Linq.Enumerable.TryGetFirstNonIterator[TSource](IEnumerable`1, Boolean&) + 0x53
	E DOTNET  :    at Java.Interop.ManagedPeer.GetTypeFromSignature(JniRuntime.JniTypeManager, JniTypeSignature, String) + 0x6a
	E DOTNET  :    at Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr jnienv, IntPtr klass, IntPtr n_nativeClass, IntPtr n_methods) + 0x11d
	E DOTNET  : --- End of stack trace from previous location ---
	E DOTNET  :    at Java.Interop.
	E DOTNET  :
	--------- beginning of crash
	F libc    : Fatal signal 6 (SIGABRT), code -6 (SI_TKILL) in tid 8165 (no.ui.demo.naot), pid 8165 (no.ui.demo.naot)
	F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
	F DEBUG   : Build fingerprint: 'google/sdk_gphone_x86_64/generic_x86_64:9/PSR1.180720.075/5124027:user/release-keys'
	F DEBUG   : Revision: '0'
	F DEBUG   : ABI: 'x86_64'
	F DEBUG   : pid: 8165, tid: 8165, name: no.ui.demo.naot  >>> com.nventive.uno.ui.demo.naot <<<
	F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
	F DEBUG   :     rax 0000000000000000  rbx 0000000000001fe5  rcx 00007bee94d69b98  rdx 0000000000000006
	F DEBUG   :     r8  00007ffe68c985b0  r9  00007ffe68c985b0  r10 00007ffe68c985b0  r11 0000000000000246
	F DEBUG   :     r12 00007bedf85be38c  r13 0000000000000000  r14 0000000000001fe5  r15 00007ffe68c986e8
	F DEBUG   :     rdi 0000000000001fe5  rsi 0000000000001fe5
	F DEBUG   :     rbp 00007ffe68c98730  rsp 00007ffe68c986d8  rip 00007bee94d69b98
	F DEBUG   :
	F DEBUG   : backtrace:
	F DEBUG   :     #00 pc 0000000000026b98  /system/lib64/libc.so (syscall+24)
	F DEBUG   :     #01 pc 0000000000029775  /system/lib64/libc.so (abort+101)
	F DEBUG   :     #02 pc 0000000002dfc298  /data/app/com.nventive.uno.ui.demo.naot-G-PdZd4xCgJDY9vLPv4UWA==/lib/x86_64/libUno.Gallery.so (offset 0x2d0f000)
	F DEBUG   :     #03 pc 000000000363e5db  /data/app/com.nventive.uno.ui.demo.naot-G-PdZd4xCgJDY9vLPv4UWA==/lib/x86_64/libUno.Gallery.so (offset 0x2d0f000)
	F DEBUG   :     #04 pc 0000000000dc1aff  [anon:.bss:00007bedfaaab000]

PR unoplatform/uno#22834 fixes the issue, but before we merge it we want an *integration test* that exercises this codepath.

Uno.Gallery was chosen as the integration test app. :-)

(It can't be in unoplatform/uno because to reproduce the bug it needs to build against published NuGet paackages, and unoplatform/uno only uses in-tree build artifacts; [see also][0].)

Update Uno.Gallery so that CI includes a new set of jobs, which:

 1. Builds Uno.Gallery for Android+Skia+NativeAOT,
 2. Installs the resulting APK on an emulator,
 3. Launches the app via a new `Instrumentation` subclass.

We can't use "normal" UI Testing a'la f31954e1 because [Uno.UITest doesn't support Skia][1], and the crash descibed above *requires* a Skia environment to observe.

As the crash is observed during app startup, we can instead use an `Instrumentation` which otherwise does nothing, then run:

	adb shell am instrument -w com.nventive.uno.ui.demo.naot/my.MainInstrumentation

and check the output (logged to the executing console).  If it has:

	INSTRUMENTATION_CODE: -1

then the app launched successfully; otherwise, Something Went Wrong™ (presumably it crashed).

[0]: https://github.com/unoplatform/uno/issues/22832#issuecomment-4076956331
[1]: https://platform.uno/docs/articles/external/uno.uitest/doc/using-uno-uitest.html

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->