### PR TITLE
fix(ci): add Linux host disk cleanup for CI builds

### DIFF
--- a/build/templates/host-cleanup-linux.yml
+++ b/build/templates/host-cleanup-linux.yml
@@ -1,23 +1,16 @@
 steps:
 - bash: |
-    # This list is based on what the base image contains and
-    # may need to be adjusted as new software gets installed.
-    # Use the `du` command below to determine what can be
-    # uninstalled.
-    
-    rm -fR ~/.cargo
-    rm -fR ~/.rustup
-    rm -fR ~/.dotnet
-    sudo rm -fR /usr/share/swift
-    sudo rm -fR /opt/microsoft/msedge
-    sudo rm -fR /usr/local/.ghcup
-    sudo rm -fR /usr/lib/mono
-    sudo snap remove lxd
-    sudo snap remove core20
-    sudo apt remove snapd
-
-    df -h
-    # du -h -d 3 /
+    echo "=== Disk usage BEFORE cleanup ==="
+    df -h /
+    sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+    sudo snap remove lxd --purge || true
+    sudo snap remove core20 --purge || true
+    sudo snap remove snapd --purge || true
+    sudo apt-get purge -y snapd || true
+    echo "=== Disk usage AFTER cleanup ==="
+    df -h /
+  displayName: 'Free disk space (Linux)'
+  condition: eq(variables['Agent.OS'], 'Linux')
 
   displayName: 'Cleanup unused image dependencies (Linux)'
   condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/templates/host-cleanup-linux.yml
+++ b/build/templates/host-cleanup-linux.yml
@@ -1,16 +1,35 @@
+# Reusable AzDO template: Cleanup unused dependencies on Linux CI agents.
+#
+# This list is based on what the base image contains and
+# may need to be adjusted as new software gets installed.
+# Use the `du` command to determine what can be uninstalled.
 steps:
-- bash: |
-    echo "=== Disk usage BEFORE cleanup ==="
-    df -h /
-    sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-    sudo snap remove lxd --purge || true
-    sudo snap remove core20 --purge || true
-    sudo snap remove snapd --purge || true
-    sudo apt-get purge -y snapd || true
-    echo "=== Disk usage AFTER cleanup ==="
-    df -h /
-  displayName: 'Free disk space (Linux)'
-  condition: eq(variables['Agent.OS'], 'Linux')
+  - bash: |
+      # Use sudo only when available (containers may not have it)
+      if command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+      else
+        SUDO=""
+      fi
 
-  displayName: 'Cleanup unused image dependencies (Linux)'
-  condition: eq(variables['Agent.OS'], 'Linux')
+      echo "Disk space before cleanup:"
+      df -h /
+
+      rm -rf ~/.cargo ~/.rustup ~/.dotnet
+
+      $SUDO rm -rf /usr/share/swift || true
+      $SUDO rm -rf /opt/microsoft/msedge || true
+      $SUDO rm -rf /usr/local/.ghcup || true
+      $SUDO rm -rf /usr/lib/mono || true
+      $SUDO rm -rf /usr/local/lib/android || true
+      $SUDO rm -rf /opt/ghc || true
+      $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
+
+      $SUDO snap remove lxd || true
+      $SUDO snap remove core20 || true
+      $SUDO apt-get purge -y snapd || true
+
+      echo "Disk space after cleanup:"
+      df -h /
+    displayName: Cleanup unused host dependencies
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/templates/host-cleanup-linux.yml
+++ b/build/templates/host-cleanup-linux.yml
@@ -5,9 +5,9 @@
 # Use the `du` command to determine what can be uninstalled.
 steps:
   - bash: |
-      # Use sudo only when available (containers may not have it)
-      if command -v sudo >/dev/null 2>&1; then
-        SUDO="sudo"
+      # Use sudo only when available and non-interactive (no password prompt)
+      if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+        SUDO="sudo -n"
       else
         SUDO=""
       fi
@@ -15,7 +15,7 @@ steps:
       echo "Disk space before cleanup:"
       df -h /
 
-      rm -rf ~/.cargo ~/.rustup ~/.dotnet
+      rm -rf ~/.cargo ~/.rustup ~/.dotnet || true
 
       $SUDO rm -rf /usr/share/swift || true
       $SUDO rm -rf /opt/microsoft/msedge || true
@@ -25,9 +25,14 @@ steps:
       $SUDO rm -rf /opt/ghc || true
       $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
 
-      $SUDO snap remove lxd || true
-      $SUDO snap remove core20 || true
-      $SUDO apt-get purge -y snapd || true
+      if command -v snap >/dev/null 2>&1; then
+        timeout 60s $SUDO snap remove lxd || true
+        timeout 60s $SUDO snap remove core20 || true
+      fi
+
+      if command -v apt-get >/dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive timeout 120s $SUDO apt-get purge -y snapd || true
+      fi
 
       echo "Disk space after cleanup:"
       df -h /


### PR DESCRIPTION
## What
Adds a Linux host disk cleanup step to all Linux CI jobs to reclaim disk space by removing unused pre-installed software.

## Why
Linux CI agents accumulate ~20–30 GB of pre-installed software (Cargo, Rust, Swift, Edge, GHC, Mono, Android SDK, CodeQL, snapd) that is not needed for builds. This cleanup step runs at the start of each Linux job to ensure sufficient disk space.

## Details
- Adds a reusable AzDO template (`host-cleanup-linux.yml`) with inline cleanup script
- Cleanup is conditional on Linux (`condition: eq(variables['Agent.OS'], 'Linux')`)
- Uses `sudo -n` (non-interactive) probe to work safely in both host and container environments
- All removals are best-effort (`|| true`) with `timeout` guards on snap/apt-get commands
- Uses `DEBIAN_FRONTEND=noninteractive` for apt-get to prevent dpkg prompts

Part of org-wide CI disk cleanup initiative.
Related to https://github.com/unoplatform/uno.rider/pull/480