### PR TITLE
fix(ci): harden Android NativeAOT instrumentation test scripts against transient failures

### DIFF
--- a/build/scripts/android-sdk-emu.inc.sh
+++ b/build/scripts/android-sdk-emu.inc.sh
@@ -74,20 +74,41 @@ EMU_UPDATE_FILE="$HOME/.android/emu-update-last-check.ini"
 
 mkdir -p "$UNO_UITEST_SCREENSHOT_PATH"
 
+# Retry wrapper for sdkmanager --install to handle transient network/unzip failures.
+# Retries up to 3 times with increasing back-off (10s, 20s).
+sdkmanager_install() {
+	local max_attempts=3
+	local attempt=1
+	while (( attempt <= max_attempts )); do
+		if echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" \
+			"--sdk_root=${ANDROID_HOME}" --install "$@" | tr '\r' '\n' | uniq; then
+			return 0
+		fi
+		if (( attempt < max_attempts )); then
+			local delay=$((attempt * 10))
+			echo "sdkmanager --install $* failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+			sleep "$delay"
+		fi
+		((attempt++))
+	done
+	echo "sdkmanager --install $* failed after $max_attempts attempts"
+	return 1
+}
+
 install_android_sdk() {
 	SIMULATOR_APILEVEL="$1"
 
 	if [[ ! -f "$SDK_MGR_TOOLS_FLAG" ]]; then
 		touch "$SDK_MGR_TOOLS_FLAG"
 
-		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'tools'| tr '\r' '\n' | uniq
-		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'platform-tools'  | tr '\r' '\n' | uniq
-		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'build-tools;36.0.0' | tr '\r' '\n' | uniq
-		echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install 'extras;android;m2repository' | tr '\r' '\n' | uniq
+		sdkmanager_install 'tools'
+		sdkmanager_install 'platform-tools'
+		sdkmanager_install 'build-tools;36.0.0'
+		sdkmanager_install 'extras;android;m2repository'
 	fi
 
-	echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install "platforms;android-$SIMULATOR_APILEVEL" | tr '\r' '\n' | uniq
-	echo "y" | "$LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager" "--sdk_root=${ANDROID_HOME}" --install "system-images;android-$SIMULATOR_APILEVEL;google_apis_playstore;$ANDROID_SIMULATOR_ABI" | tr '\r' '\n' | uniq
+	sdkmanager_install "platforms;android-$SIMULATOR_APILEVEL"
+	sdkmanager_install "system-images;android-$SIMULATOR_APILEVEL;google_apis_playstore;$ANDROID_SIMULATOR_ABI"
 }
 
 if [[ ! -f "$EMU_UPDATE_FILE" ]]; then
@@ -102,7 +123,10 @@ if [[ -f "$AVD_CONFIG_FILE" ]]; then
 else
 	# Install AVD files
 	install_android_sdk "$ANDROID_SIMULATOR_APILEVEL"
-	install_android_sdk 36
+
+	# API-36 platform is needed for build-tools/apkanalyzer, but the full
+	# system image (~1.5 GB) is not used for the emulator — skip it.
+	sdkmanager_install "platforms;android-36"
 
 	if [[ -f "$ANDROID_HOME/platform-tools/platform-tools/adb" ]]; then
 		# It appears that the platform-tools 29.0.6 are extracting into an incorrect path

--- a/build/scripts/android-test-run.sh
+++ b/build/scripts/android-test-run.sh
@@ -23,7 +23,22 @@ export ANDROID_SIMULATOR_APILEVEL=34
 
 source "$BUILD_SOURCESDIRECTORY/build/scripts/android-sdk-emu.inc.sh"
 
-"$ANDROID_HOME/platform-tools/adb" install -r "$UNO_TEST_ANDROIDAPK_PATH"
+# Retry adb install — the emulator may be transiently unresponsive right after boot.
+adb_install_ok=false
+for i in 1 2 3; do
+	if "$ANDROID_HOME/platform-tools/adb" install -r "$UNO_TEST_ANDROIDAPK_PATH"; then
+		adb_install_ok=true
+		break
+	fi
+	if [ "$i" -lt 3 ]; then
+		echo "adb install failed (attempt $i/3), retrying in ${i}s..."
+		sleep "$i"
+	fi
+done
+if [ "$adb_install_ok" = false ]; then
+	echo "ERROR: adb install failed after 3 attempts."
+	exit 1
+fi
 
 package_name=$("$LATEST_CMDLINE_TOOLS_PATH/bin/apkanalyzer" manifest application-id "$UNO_TEST_ANDROIDAPK_PATH")
 

--- a/build/scripts/android-uitest-wait-systemui.sh
+++ b/build/scripts/android-uitest-wait-systemui.sh
@@ -69,8 +69,10 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     case $UI_FOCUS in
     *"Not Responding"*)
         echo "Detected an ANR! Dismissing..."
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_DPAD_RIGHT
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_ENTER
+        # Guard keyevent calls: adb can transiently return 255 when the
+        # emulator is still settling, and set -e would kill the script.
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_DPAD_RIGHT || true
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_ENTER || true
     ;;  
     *"Launcher"*)
         LAUNCHER_READY=true
@@ -86,17 +88,17 @@ while [[ -z ${LAUNCHER_READY} ]]; do
         # For some reason the messaging app can be brought up in front
         # (DEBUG) Current focus:   mCurrentFocus=Window{1170051 u0 com.google.android.apps.messaging/com.google.android.apps.messaging.ui.ConversationListActivity}
         # Try bringing back the home screen to check on the launcher.
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_HOME
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_HOME || true
     ;;
     esac
 done
 
 # Force terminate system UI to restart clean
-"$ANDROID_HOME/platform-tools/adb" shell am force-stop com.android.systemui
+"$ANDROID_HOME/platform-tools/adb" shell am force-stop com.android.systemui || true
 
-"$ANDROID_HOME/platform-tools/adb" shell settings put global animator_duration_scale 0
-"$ANDROID_HOME/platform-tools/adb" shell settings put global transition_animation_scale 0
-"$ANDROID_HOME/platform-tools/adb" shell settings put global window_animation_scale 0
+"$ANDROID_HOME/platform-tools/adb" shell settings put global animator_duration_scale 0 || true
+"$ANDROID_HOME/platform-tools/adb" shell settings put global transition_animation_scale 0 || true
+"$ANDROID_HOME/platform-tools/adb" shell settings put global window_animation_scale 0 || true
 
 echo "Launcher is ready!"
 


### PR DESCRIPTION
## Summary

Fixes transient CI flakiness in the Android+Skia+NativeAOT Instrumentation Test pipeline introduced by https://github.com/unoplatform/Uno.Gallery/pull/1245.

Three flakiness modes were observed:
1. **`sdkmanager --install` dying at &#34;33% Unzipping&#34;** — exits with code 1 on transient network/IO issues, and `set -euxo pipefail` aborts the entire pipeline immediately with no retry. First observed in [CI build 204968](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=204968&amp;view=logs).
2. **Emulator ANR crashing the boot-wait script** — `adb shell input keyevent` returns exit 255 while dismissing an &#34;Application Not Responding: system&#34; dialog during emulator boot, and `set -e` kills the script. First observed in [canary build 205041 (Attempt 1)](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=205041&amp;view=logs&amp;j=0296a2a4-770a-5dd9-a848-f63fe824e599&amp;t=a89cc937-d44f-586b-561a-8707d5099fb1&amp;s=f6ddb056-70fd-51b3-f0fd-0c40972f6816).
3. **Job never reaching `adb shell am instrument`** — `adb install` can fail transiently right after emulator boot, again aborting due to `set -e`.

### Changes

**Fix 1 — `sdkmanager_install()` retry wrapper** (`android-sdk-emu.inc.sh`)
- Wraps all `sdkmanager --install` calls in a function that retries up to 3 times with increasing back-off (10 s, 20 s).
- Addresses the &#34;33% Unzipping&#34; flakiness observed in [CI build 204968](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=204968&amp;view=logs).

**Fix 2 — Stop downloading unused API-36 system image** (`android-sdk-emu.inc.sh`)
- `install_android_sdk 36` was downloading the full `system-images;android-36;google_apis_playstore;x86_64` (~1.5 GB), but the emulator AVD is always created with API-34.
- Now only installs `platforms;android-36` (needed for build-tools/apkanalyzer), saving ~1.5 GB of download and reducing the window for transient failures.

**Fix 3 — `adb install` retry** (`android-test-run.sh`)
- Adds a 3-attempt retry loop with back-off around `adb install -r`, since the emulator may be transiently unresponsive right after boot.

**Fix 4 — Guard `adb` keyevent calls against transient exit 255** (`android-uitest-wait-systemui.sh`)
- Appends `|| true` to all non-critical `adb shell input keyevent` and `adb shell` calls in the emulator boot-wait loop and post-boot setup.
- Under `set -e`, a transient exit 255 from `adb shell input keyevent KEYCODE_ENTER` (while dismissing an ANR dialog) was killing the entire script. The loop can now retry on the next iteration instead of aborting.
- Directly addresses the emulator ANR failure in [canary build 205041 (Attempt 1)](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=205041&amp;view=logs&amp;j=0296a2a4-770a-5dd9-a848-f63fe824e599&amp;t=a89cc937-d44f-586b-561a-8707d5099fb1&amp;s=f6ddb056-70fd-51b3-f0fd-0c40972f6816).

### Related

- Follow-up to https://github.com/unoplatform/Uno.Gallery/pull/1245 (feat: Test Android+Skia+NativeAOT on CI)
- Related to https://github.com/unoplatform/uno/pull/22834 (NativeAOT startup fix)

Note: No related issue (CI maintenance).
