### PR TITLE
chore: bump and pin packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
 		<PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.200" />
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Disposables" Version="4.0.1" />
+		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
 		<PackageVersion Include="CommunityToolkit.WinUI.Lottie" Version="8.0.280225" />
 		<PackageVersion Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
@@ -33,7 +34,7 @@
 		<PackageVersion Include="Microsoft.TypeScript.Compiler" Version="3.1.5" />
 		<PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.6.4" />
 		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1-RTM" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
 		<PackageVersion Include="nventive.Nimue.Application.Packaging" Version="0.1.0-alpha.58" />
 		<PackageVersion Include="Xamarin.TestCloud.Agent" Version="0.23.2" />
 	</ItemGroup>

--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -98,6 +98,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" />
+		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 		<!--<PackageReference Include="SkiaSharp.Skottie" Condition="$(IsSkiaWasm) OR $(IsSkiaAndroid)" />-->
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## PR Type:

🐞 Bugfix
🏗️ Build or CI related changes

## What is the current behavior? 🤔

The canary build on `canaries/dev` fails during Release restore with two NU1605 (package downgrade) errors:

1. **`Uno.Core.Extensions.Logging.Singleton`** — The `unoplatformCanaryUpdater` bumps `Uno.Core.Extensions.Compatibility` to `4.2.0-dev.11`, which transitively requires `Uno.Core.Extensions.Logging.Singleton >= 4.2.0-dev.11`. However, `Logging.Singleton` was never listed in `Directory.Packages.props`, so the updater couldn't bump it, and NuGet resolved it to the lower `4.1.1` from another dependency path.

2. **`Microsoft.Windows.SDK.BuildTools`** — `Uno.UI.HotDesign 1.19.0-dev.476` requires `>= 10.0.28000.1721`, but the project pinned `10.0.28000.1-RTM` (a prerelease tag with a lower version). The canary updater doesn't touch this package since it's authored by Microsoft, not Uno/nventive.

## What is the new behavior? 🚀

- Added `Uno.Core.Extensions.Logging.Singleton` (version `4.1.1`) to `Directory.Packages.props` and as a `PackageReference` in `Uno.Gallery.csproj`. The canary updater will now discover and bump it alongside the other `Uno.Core.Extensions.*` packages.
- Updated `Microsoft.Windows.SDK.BuildTools` from `10.0.28000.1-RTM` to `10.0.28000.1721` to satisfy the version required by `Uno.UI.HotDesign` dev builds.

Both fixes have been verified locally by simulating the canary updater's version bumps.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

No functional changes — this is a dependency version fix only. The stable (non-canary) build is unaffected since these versions are compatible with the current Uno SDK 6.5.29.
