### PR TITLE
fix(canary): override SkiaSharp to 4.148.0 on native iOS canary builds

### DIFF
--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -121,6 +121,17 @@
 		<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 	</PropertyGroup>
 
+	<!--
+	SkiaSharp 3.119.4 (pinned by Uno.Sdk dev) ships its iOS assets as net10.0-ios26.2, which cannot be
+	consumed when targeting iOS 26.1 or lower. NuGet then falls back to the platform-neutral net10.0
+	assembly, whose SKSwapChainPanel is not ObjC-registered, and the managed-static registrar fails with
+	MT0099 on native-rendering iOS Release builds. Override to a SkiaSharp version shipping iOS 26.0
+	assets until the Uno.Sdk moves off 3.119.4. See https://github.com/unoplatform/Uno.Gallery/issues/1253.
+	-->
+	<PropertyGroup Condition="'$(UseNativeRendering)'=='true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' and $(BUILD_SOURCEBRANCH.StartsWith('refs/heads/canaries'))">
+		<SkiaSharpVersion>4.148.0</SkiaSharpVersion>
+	</PropertyGroup>
+
 	<ItemGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
 		<TrimmerRootDescriptor Include="Platforms/iOS/LinkerConfig.xml"/>
 	</ItemGroup>


### PR DESCRIPTION
 Related to https://github.com/unoplatform/uno/issues/23680

## Problem
The canary native iOS Release build has failed daily since 2026-05-25 with:

```
ILLINK : error MT0099: Can't create a token reference to an unregistered type when using the managed static registrar: SkiaSharp.Views.Windows.SKSwapChainPanel
error NETSDK1144: Optimizing assemblies for size failed.
```

SkiaSharp 3.119.4 (published 2026-05-25, pinned by Uno.Sdk dev) ships its iOS assets as `net10.0-ios26.2`. CI builds with Xcode 26.1.1 / iOS 26.1, so NuGet cannot select the platform asset and silently falls back to the platform-neutral `net10.0` assembly. That assembly's `SKSwapChainPanel` has no ObjC `[Register]` attribute (verified by binary inspection), and on the native-rendering head — where `FrameworkElement` derives from `NSObject` — the managed-static registrar fails at ILLink. The Skia-renderer iOS leg is unaffected.

The upstream TFM fix (mono/SkiaSharp#3798, 26.2 → 26.0) shipped in SkiaSharp 4.147.0-preview.2+; no 3.119.5 backport exists on nuget.org or the skia-eap feed.

## Fix
Override `SkiaSharpVersion` to **4.148.0** (ships `net10.0-ios26.0` assets) via the Uno.Sdk's override property, scoped to `UseNativeRendering=true` + iOS + `canaries/*` branches so master keeps the stable Uno.Sdk pin (3.119.1) for the store app.

## Verification (local, Xcode 26.1.1 + iOS workload 26.1, mirroring CI)
- Reproduced the exact MT0099/NETSDK1144 failure with Uno.Sdk 6.7.0-dev.105 before the change.
- With the override: all SkiaSharp packages unify on 4.148.0 with proper `net10.0-ios26.0` assets, and `dotnet publish -f net10.0-ios -c Release -p:UseNativeRendering=true` succeeds end-to-end (.app/.ipa produced).
- Without the canary branch variable the override is inert: dev SDK resolves 3.119.4, stable SDK resolves 3.119.1, unchanged.

## Notes
- On canary, Lottie/Skottie and Svg.Skia now run against SkiaSharp 4.148.0 — worth watching the iOS UI tests for rendering regressions.
- Remove this override once the Uno.Sdk dev pin moves off 3.119.4 (or a 3.119.x backport ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)