### PR TITLE
fix(canary): pin SkiaSharp to 4.148.0 on native iOS

### DIFF
--- a/Uno.Gallery/Uno.Gallery.csproj
+++ b/Uno.Gallery/Uno.Gallery.csproj
@@ -122,6 +122,17 @@
 		<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 	</PropertyGroup>
 
+	<!--
+	SkiaSharp 3.119.4 (pinned by Uno.Sdk dev) ships iOS assets as net10.0-ios26.2, unusable when targeting
+	iOS 26.1 or lower; NuGet then falls back to the platform-neutral net10.0 assembly whose SKSwapChainPanel
+	is not ObjC-registered, so the managed-static registrar fails with MT0099 on native-rendering iOS Release
+	builds. Override to SkiaSharp v4 (ships ios26.0 assets) until the Uno.Sdk moves off 3.119.4 (7.0).
+	Canary-only (canaries/dev). See https://github.com/unoplatform/uno/issues/23680
+	-->
+	<PropertyGroup Condition="'$(UseNativeRendering)'=='true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios'">
+		<SkiaSharpVersion>4.148.0</SkiaSharpVersion>
+	</PropertyGroup>
+
 	<ItemGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
 		<TrimmerRootDescriptor Include="Platforms/iOS/LinkerConfig.xml"/>
 	</ItemGroup>


### PR DESCRIPTION
Canary-only workaround on `canaries/dev` (default branch left untouched). Replaces #1254, which targeted `master` — moved here per the team convention of keeping canary-only adjustments on `canaries/dev`.

Pins SkiaSharp to **4.148.0** for **native-iOS** Release builds. The dev Uno.Sdk resolves SkiaSharp `3.119.4`, whose iOS assets are `net10.0-ios26.2` (unusable on the iOS 26.1 workload) — NuGet falls back to the neutral `net10.0` assembly whose `SKSwapChainPanel` isn't ObjC-registered, so the managed-static registrar fails with `MT0099`. v4 ships the corrected `ios26.0` assets. Reverts once SkiaSharp ships a fixed `3.119.x` or the Uno.Sdk moves to v4 in 7.0.

Related to https://github.com/unoplatform/uno/issues/23680