### PR TITLE
ci(canary): bump nuget.updater to 1.3.1

### DIFF
--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -31,7 +31,7 @@ steps:
       usePrivateFeed: false
       mergeBranch: true
       branchToMerge: master
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       packageAuthor: 'nventive,uno platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
 
@@ -44,7 +44,7 @@ steps:
       useNuGetOrg: true
       mergeBranch: true
       branchToMerge: master
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       nugetVersion: dev
       packageAuthor: 'nventive,unoplatform,uno platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Summary.md'


### PR DESCRIPTION
Bumps the canary `nuget.updater` to **1.3.1** (both steps) for consistency with the other canaries (Themes / Toolkit / Rider / Studio / extensions all on 1.3.1) and to pick up the property-package fallback fix.

Single-source-of-truth on the default branch; once merged, `canaries/dev` will be synced with `master` to inherit this along with the rest of the default-branch changes.